### PR TITLE
add remark field on order

### DIFF
--- a/trade/jsontypes/types.go
+++ b/trade/jsontypes/types.go
@@ -52,6 +52,7 @@ type Order struct {
 	TriggerStatus    string `json:"trigger_status"`
 	Currency         string `json:"currency"`
 	OutsideRth       string `json:"outside_rth"`
+	Remark           string `json:"remark"`
 }
 
 // AccountBalances has a AccountBalance list

--- a/trade/types.go
+++ b/trade/types.go
@@ -108,6 +108,7 @@ type Order struct {
 	TriggerStatus    TriggerStatus
 	Currency         string
 	OutsideRth       OutsideRTH
+	Remark           string
 }
 
 // AccountBalances has a AccountBalance list


### PR DESCRIPTION
add remark field on [get history orders](https://open.longportapp.com/en/docs/trade/order/history_orders) and [get today orders](https://open.longportapp.com/en/docs/trade/order/today_orders)