### PR TITLE
Add order detail interface and add estimate maximum purchase quantity interface

### DIFF
--- a/trade/context.go
+++ b/trade/context.go
@@ -207,6 +207,19 @@ func (c *TradeContext) OrderDetail(ctx context.Context, orderId string) (orderDe
 	return
 }
 
+// EstimateMaxPurchaseQuantity is used for estimating the maximum purchase quantity for Hong Kong and US stocks, warrants, and options.
+// Reference: https://open.longportapp.com/en/docs/trade/order/estimate_available_buy_limit
+func (c *TradeContext) EstimateMaxPurchaseQuantity(ctx context.Context, params *GetEstimateMaxPurchaseQuantity) (empqr EstimateMaxPurchaseQuantityResponse, err error) {
+	values := params.Values()
+	var resp jsontypes.EstimateMaxPurchaseQuantityResponse
+	err = c.opts.httpClient.Get(ctx, "/v1/trade/estimate/buy_limit", values, &resp)
+	if err != nil {
+		return
+	}
+	err = util.Copy(&empqr, resp)
+	return
+}
+
 // Close
 func (c *TradeContext) Close() error {
 	return c.core.Close()

--- a/trade/context.go
+++ b/trade/context.go
@@ -193,6 +193,20 @@ func (c *TradeContext) MarginRatio(ctx context.Context, symbol string) (marginRa
 	return
 }
 
+// OrderDetail is used for order detail query
+// Reference: https://open.longportapp.com/en/docs/trade/order/order_detail
+func (c *TradeContext) OrderDetail(ctx context.Context, orderId string) (orderDetail OrderDetail, err error) {
+	values := url.Values{}
+	values.Add("order_id", orderId)
+	var resp jsontypes.OrderDetail
+	err = c.opts.httpClient.Get(ctx, "/v1/trade/order", values, &resp)
+	if err != nil {
+		return
+	}
+	err = util.Copy(&orderDetail, resp)
+	return
+}
+
 // Close
 func (c *TradeContext) Close() error {
 	return c.core.Close()

--- a/trade/jsontypes/types.go
+++ b/trade/jsontypes/types.go
@@ -208,3 +208,74 @@ type MarginRatio struct {
 	MmFactor string `json:"mm_factor,omitempty"`
 	FmFactor string `json:"fm_factor,omitempty"`
 }
+
+type OrderChargeItem struct {
+	Code string           `json:"code"`
+	Name string           `json:"name"`
+	Fees []OrderChargeFee `json:"fees"`
+}
+
+type OrderChargeDetail struct {
+	TotalAmount string            `json:"total_amount"`
+	Currency    string            `json:"currency"`
+	Items       []OrderChargeItem `json:"items"`
+}
+
+type OrderChargeFee struct {
+	Code     string `json:"code"`
+	Name     string `json:"name"`
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+type OrderHistoryDetail struct {
+	// Executed price for executed orders, submitted price for expired,
+	// canceled, rejected orders, etc.
+	Price string `json:"price"`
+	// Executed quantity for executed orders, remaining quantity for expired,
+	// canceled, rejected orders, etc.
+	Quantity string `json:"quantity"`
+	Status   string `json:"status"`
+	Msg      string `json:"msg"`  // Execution or error message
+	Time     string `json:"time"` // Occurrence time
+}
+
+type OrderDetail struct {
+	OrderId                  string             `json:"order_id"`
+	Status                   string             `json:"status"`
+	StockName                string             `json:"stock_name"`
+	Quantity                 string             `json:"quantity"` // Submitted quantity
+	ExecutedQuantity         string             `json:"executed_quantity"`
+	Price                    string             `json:"price"` // Submitted price
+	ExecutedPrice            string             `json:"executed_price"`
+	SubmittedAt              string             `json:"submitted_at"`
+	Side                     string             `json:"side"` // Order side
+	Symbol                   string             `json:"symbol"`
+	OrderType                string             `json:"order_type"`
+	LastDone                 string             `json:"last_done"`
+	TriggerPrice             string             `json:"trigger_price"`
+	Msg                      string             `json:"msg"` // Rejected Message or remark
+	Tag                      string             `json:"tag"`
+	TimeInForce              string             `json:"time_in_force"`
+	ExpireDate               string             `json:"expire_date"`
+	UpdatedAt                string             `json:"update_at"`
+	TriggerAt                string             `json:"trigger_at"` // Conditional order trigger time
+	TrailingAmount           string             `json:"trailing_amount"`
+	TrailingPercent          string             `json:"trailing_precent"`
+	LimitOffset              string             `json:"limit_offset"`
+	TriggerStatus            string             `json:"trigger_status"`
+	Currency                 string             `json:"currency"`
+	OutsideRth               string             `json:"outside"` // Enable or disable outside regular trading hours
+	Remark                   string             `json:"remark"`
+	FreeStatus               string             `json:"free_status"`
+	FreeAmount               string             `json:"free_amount"`
+	FreeCurrency             string             `json:"free_currency"`
+	DeductionsStatus         string             `json:"deduction_status"`
+	DeductionsAmount         string             `json:"deductions_amount"`
+	DeductionsCurrency       string             `json:"deductions_currency"`
+	PlatformDeductedStatus   string             `json:"platform_deducted_status"`
+	PlatformDeductedAmount   string             `json:"platform_deducted_amount"`
+	PlatformDeductedCurrency string             `json:"platform_deducted_currency"`
+	History                  OrderHistoryDetail `json:"history"`
+	ChargeDetail             OrderChargeDetail  `json:"charge_detail"`
+}

--- a/trade/jsontypes/types.go
+++ b/trade/jsontypes/types.go
@@ -240,6 +240,7 @@ type OrderHistoryDetail struct {
 	Time     string `json:"time"` // Occurrence time
 }
 
+// OrderDetail is for get order detail response
 type OrderDetail struct {
 	OrderId                  string             `json:"order_id"`
 	Status                   string             `json:"status"`
@@ -278,4 +279,10 @@ type OrderDetail struct {
 	PlatformDeductedCurrency string             `json:"platform_deducted_currency"`
 	History                  OrderHistoryDetail `json:"history"`
 	ChargeDetail             OrderChargeDetail  `json:"charge_detail"`
+}
+
+// EstimateMaxPurchaseQuantity is response for estimate maximum purchase quantity
+type EstimateMaxPurchaseQuantityResponse struct {
+	CashMaxQty   int64 `json:"cash_max_qty"`   // Cash available quantity
+	MarginMaxQty int64 `json:"margin_max_qty"` // Margin available quantity
 }

--- a/trade/jsontypes/types.go
+++ b/trade/jsontypes/types.go
@@ -283,6 +283,6 @@ type OrderDetail struct {
 
 // EstimateMaxPurchaseQuantity is response for estimate maximum purchase quantity
 type EstimateMaxPurchaseQuantityResponse struct {
-	CashMaxQty   int64 `json:"cash_max_qty"`   // Cash available quantity
-	MarginMaxQty int64 `json:"margin_max_qty"` // Margin available quantity
+	CashMaxQty   string `json:"cash_max_qty"`   // Cash available quantity
+	MarginMaxQty string `json:"margin_max_qty"` // Margin available quantity
 }

--- a/trade/jsontypes/types.go
+++ b/trade/jsontypes/types.go
@@ -242,43 +242,43 @@ type OrderHistoryDetail struct {
 
 // OrderDetail is for get order detail response
 type OrderDetail struct {
-	OrderId                  string             `json:"order_id"`
-	Status                   string             `json:"status"`
-	StockName                string             `json:"stock_name"`
-	Quantity                 string             `json:"quantity"` // Submitted quantity
-	ExecutedQuantity         string             `json:"executed_quantity"`
-	Price                    string             `json:"price"` // Submitted price
-	ExecutedPrice            string             `json:"executed_price"`
-	SubmittedAt              string             `json:"submitted_at"`
-	Side                     string             `json:"side"` // Order side
-	Symbol                   string             `json:"symbol"`
-	OrderType                string             `json:"order_type"`
-	LastDone                 string             `json:"last_done"`
-	TriggerPrice             string             `json:"trigger_price"`
-	Msg                      string             `json:"msg"` // Rejected Message or remark
-	Tag                      string             `json:"tag"`
-	TimeInForce              string             `json:"time_in_force"`
-	ExpireDate               string             `json:"expire_date"`
-	UpdatedAt                string             `json:"update_at"`
-	TriggerAt                string             `json:"trigger_at"` // Conditional order trigger time
-	TrailingAmount           string             `json:"trailing_amount"`
-	TrailingPercent          string             `json:"trailing_precent"`
-	LimitOffset              string             `json:"limit_offset"`
-	TriggerStatus            string             `json:"trigger_status"`
-	Currency                 string             `json:"currency"`
-	OutsideRth               string             `json:"outside"` // Enable or disable outside regular trading hours
-	Remark                   string             `json:"remark"`
-	FreeStatus               string             `json:"free_status"`
-	FreeAmount               string             `json:"free_amount"`
-	FreeCurrency             string             `json:"free_currency"`
-	DeductionsStatus         string             `json:"deduction_status"`
-	DeductionsAmount         string             `json:"deductions_amount"`
-	DeductionsCurrency       string             `json:"deductions_currency"`
-	PlatformDeductedStatus   string             `json:"platform_deducted_status"`
-	PlatformDeductedAmount   string             `json:"platform_deducted_amount"`
-	PlatformDeductedCurrency string             `json:"platform_deducted_currency"`
-	History                  OrderHistoryDetail `json:"history"`
-	ChargeDetail             OrderChargeDetail  `json:"charge_detail"`
+	OrderId                  string               `json:"order_id"`
+	Status                   string               `json:"status"`
+	StockName                string               `json:"stock_name"`
+	Quantity                 string               `json:"quantity"` // Submitted quantity
+	ExecutedQuantity         string               `json:"executed_quantity"`
+	Price                    string               `json:"price"` // Submitted price
+	ExecutedPrice            string               `json:"executed_price"`
+	SubmittedAt              string               `json:"submitted_at"`
+	Side                     string               `json:"side"` // Order side
+	Symbol                   string               `json:"symbol"`
+	OrderType                string               `json:"order_type"`
+	LastDone                 string               `json:"last_done"`
+	TriggerPrice             string               `json:"trigger_price"`
+	Msg                      string               `json:"msg"` // Rejected Message or remark
+	Tag                      string               `json:"tag"`
+	TimeInForce              string               `json:"time_in_force"`
+	ExpireDate               string               `json:"expire_date"`
+	UpdatedAt                string               `json:"update_at"`
+	TriggerAt                string               `json:"trigger_at"` // Conditional order trigger time
+	TrailingAmount           string               `json:"trailing_amount"`
+	TrailingPercent          string               `json:"trailing_precent"`
+	LimitOffset              string               `json:"limit_offset"`
+	TriggerStatus            string               `json:"trigger_status"`
+	Currency                 string               `json:"currency"`
+	OutsideRth               string               `json:"outside_rth"` // Enable or disable outside regular trading hours
+	Remark                   string               `json:"remark"`
+	FreeStatus               string               `json:"free_status"`
+	FreeAmount               string               `json:"free_amount"`
+	FreeCurrency             string               `json:"free_currency"`
+	DeductionsStatus         string               `json:"deductions_status"`
+	DeductionsAmount         string               `json:"deductions_amount"`
+	DeductionsCurrency       string               `json:"deductions_currency"`
+	PlatformDeductedStatus   string               `json:"platform_deducted_status"`
+	PlatformDeductedAmount   string               `json:"platform_deducted_amount"`
+	PlatformDeductedCurrency string               `json:"platform_deducted_currency"`
+	History                  []OrderHistoryDetail `json:"history"`
+	ChargeDetail             OrderChargeDetail    `json:"charge_detail"`
 }
 
 // EstimateMaxPurchaseQuantity is response for estimate maximum purchase quantity

--- a/trade/params.go
+++ b/trade/params.go
@@ -32,7 +32,7 @@ func (p params) AddDate(key string, val time.Time) {
 }
 
 func (p params) AddOptInt(key string, val int64) {
-	if val == 0 {
+	if val != 0 {
 		p.AddInt(key, val)
 	}
 }
@@ -55,8 +55,8 @@ func (p params) AddOptUint(key string, val *uint64) {
 	}
 }
 
-func (p params) AddDecimal(key string, val *decimal.Decimal) {
-	if val != nil {
+func (p params) AddOptDecimal(key string, val decimal.Decimal) {
+	if !val.IsZero() {
 		p[key] = val.String()
 	}
 }

--- a/trade/params.go
+++ b/trade/params.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/longbridgeapp/openapi-go/internal/util"
+	"github.com/shopspring/decimal"
 )
 
 type params map[string]string
@@ -51,6 +52,12 @@ func (p params) AddOptInt32(key string, val *int32) {
 func (p params) AddOptUint(key string, val *uint64) {
 	if val != nil {
 		p[key] = strconv.FormatUint(*val, 10)
+	}
+}
+
+func (p params) AddDecimal(key string, val *decimal.Decimal) {
+	if val != nil {
+		p[key] = val.String()
 	}
 }
 

--- a/trade/request_values.go
+++ b/trade/request_values.go
@@ -100,8 +100,9 @@ func (r *GetEstimateMaxPurchaseQuantity) Values() url.Values {
 	p := &params{}
 	p.Add("symbol", r.Symbol)
 	p.Add("order_type", string(r.OrderType))
-	p.AddDecimal("price", r.Price)
+	p.AddOptDecimal("price", r.Price)
 	p.Add("currency", r.Currency)
 	p.Add("order_id", r.OrderId)
+	p.Add("side", string(r.Side))
 	return p.Values()
 }

--- a/trade/request_values.go
+++ b/trade/request_values.go
@@ -92,3 +92,16 @@ func (r *GetTodayOrders) Values() url.Values {
 	}
 	return vals
 }
+
+func (r *GetEstimateMaxPurchaseQuantity) Values() url.Values {
+	if r == nil {
+		return url.Values{}
+	}
+	p := &params{}
+	p.Add("symbol", r.Symbol)
+	p.Add("order_type", string(r.OrderType))
+	p.AddDecimal("price", r.Price)
+	p.Add("currency", r.Currency)
+	p.Add("order_id", r.OrderId)
+	return p.Values()
+}

--- a/trade/requests.go
+++ b/trade/requests.go
@@ -81,7 +81,8 @@ type SubmitOrder struct {
 type GetEstimateMaxPurchaseQuantity struct {
 	Symbol    string
 	OrderType OrderType
-	Price     *decimal.Decimal
+	Price     decimal.Decimal
 	Currency  string
 	OrderId   string
+	Side      OrderSide
 }

--- a/trade/requests.go
+++ b/trade/requests.go
@@ -77,3 +77,11 @@ type SubmitOrder struct {
 	Remark            string
 	TimeInForce       TimeType // required
 }
+
+type GetEstimateMaxPurchaseQuantity struct {
+	Symbol    string
+	OrderType OrderType
+	Price     *decimal.Decimal
+	Currency  string
+	OrderId   string
+}

--- a/trade/types.go
+++ b/trade/types.go
@@ -17,6 +17,9 @@ type TriggerStatus string
 type BalanceType int32
 type OfDirection int32
 type TimeType string
+type CommissionFreeStatus string
+type DeductionStatus string
+type ChargeCategoryCode string
 
 const (
 	// Balance type
@@ -58,6 +61,23 @@ const (
 	OutsideRTHOnly    OutsideRTH = "RTH_ONLY"          // Regular trading hour only
 	OutsideRTHAny     OutsideRTH = "ANY_TIME"          // Any time
 	OutsideRTHUnknown OutsideRTH = "UnknownOutsideRth" // Default is UnknownOutsideRth when the order is not a US stock
+
+	// Commission-free Status
+	CommissionFreeStatusNone      CommissionFreeStatus = "None"
+	CommissionFreeStatusCaculated CommissionFreeStatus = "Calculated" // Commission-free amount to be calculated
+	CommissionFreeStatusPending   CommissionFreeStatus = "Pending"    // Pending commission-free
+	CommissionFreeStatusReady     CommissionFreeStatus = "Ready"      // Commission-free applied
+
+	// Deduction status/Cashback Status
+	DeductionStatusNone    DeductionStatus = "NONE"
+	DeductionStatusNoData  DeductionStatus = "NO_DATA"
+	DeductionStatusPending DeductionStatus = "PENDING"
+	DeductionStatusDone    DeductionStatus = "DONE"
+
+	// Charge category code
+	ChargeCategoryCodeUnknown    ChargeCategoryCode = "UNKNOWN"
+	ChargeCategoryCodeBrokerFees ChargeCategoryCode = "BROKER_FEES"
+	ChargeCategoryCodeThirdFees  ChargeCategoryCode = "THIRD_FEES"
 )
 
 // Execution is execution details
@@ -109,6 +129,76 @@ type Order struct {
 	Currency         string
 	OutsideRth       OutsideRTH
 	Remark           string
+}
+
+type OrderChargeItem struct {
+	Code ChargeCategoryCode
+	Name string
+	Fees []OrderChargeFee
+}
+
+type OrderChargeDetail struct {
+	TotalAmount decimal.Decimal
+	Currency    string
+	Items       []OrderChargeItem
+}
+
+type OrderChargeFee struct {
+	Code ChargeCategoryCode
+	Name string
+	Fees []OrderChargeFee
+}
+
+type OrderHistoryDetail struct {
+	// Executed price for executed orders, submitted price for expired,
+	// canceled, rejected orders, etc.
+	Price decimal.Decimal
+	// Executed quantity for executed orders, remaining quantity for expired,
+	// canceled, rejected orders, etc.
+	Quantity int64
+	Status   OrderStatus
+	Msg      string // Execution or error message
+	Time     string // Occurrence time
+}
+
+type OrderDetail struct {
+	OrderId                  string
+	Status                   OrderStatus
+	StockName                string
+	Quantity                 int64 // Submitted quantity
+	ExecutedQuantity         int64
+	Price                    *decimal.Decimal // Submitted price
+	ExecutedPrice            *decimal.Decimal
+	SubmittedAt              string    // Submitted time
+	Side                     OrderSide /// Order side
+	Symbol                   string
+	OrderType                OrderType
+	LastDone                 *decimal.Decimal
+	TriggerPrice             *decimal.Decimal
+	Msg                      string // Rejected Message or remark
+	Tag                      OrderTag
+	TimeInForce              TimeType
+	ExpireDate               string
+	UpdatedAt                string
+	TriggerAt                string // Conditional order trigger time
+	TrailingAmount           *decimal.Decimal
+	TrailingPercent          *decimal.Decimal
+	LimitOffset              *decimal.Decimal
+	TriggerStatus            TriggerStatus
+	Currency                 string
+	OutsideRth               OutsideRTH /// Enable or disable outside regular trading hours
+	Remark                   string
+	FreeStatus               CommissionFreeStatus
+	FreeAmount               *decimal.Decimal
+	FreeCurrency             string
+	DeductionsStatus         DeductionStatus
+	DeductionsAmount         *decimal.Decimal
+	DeductionsCurrency       string
+	PlatformDeductedStatus   DeductionStatus
+	PlatformDeductedAmount   *decimal.Decimal
+	PlatformDeductedCurrency string
+	History                  OrderHistoryDetail
+	ChargeDetail             OrderChargeDetail
 }
 
 // AccountBalances has a AccountBalance list

--- a/trade/types.go
+++ b/trade/types.go
@@ -345,3 +345,9 @@ type MarginRatio struct {
 	MmFactor *decimal.Decimal // Maintain the initial margin ratio
 	FmFactor *decimal.Decimal // Forced close-out margin ratio
 }
+
+// EstimateMaxPurchaseQuantity is response for estimate maximum purchase quantity
+type EstimateMaxPurchaseQuantityResponse struct {
+	CashMaxQty   int64 // Cash available quantity
+	MarginMaxQty int64 // Margin available quantity
+}


### PR DESCRIPTION
1. Add order detail interface. 
Seeing doc on https://open.longportapp.com/en/docs/trade/order/order_detail.
1. Add estimate maximum purchase quantity interface.
Seeing doc on https://open.longportapp.com/en/docs/trade/order/estimate_available_buy_limit.