### PR TITLE
新增IPO openapi接口

### DIFF
--- a/ipo/context.go
+++ b/ipo/context.go
@@ -1,0 +1,296 @@
+// Package ipo provides a client for the Longbridge IPO OpenAPI.
+// It covers IPO subscription submission, modification, cancellation, and queries.
+package ipo
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/longbridge/openapi-go/config"
+	httplib "github.com/longbridge/openapi-go/http"
+	"github.com/longbridge/openapi-go/ipo/jsontypes"
+)
+
+// IPOContext is a client for the Longbridge IPO API.
+//
+// Example:
+//
+//	conf, err := config.New()
+//	ictx, err := ipo.NewFromCfg(conf)
+//	result, err := ictx.SubmitOrder(context.Background(), &ipo.SubmitOrderRequest{
+//	    Symbol:  "9988.HK",
+//	    SubQty:  "1000",
+//	    BatchID: 12345,
+//	    Method:  1,
+//	})
+type IPOContext struct {
+	httpClient *httplib.Client
+}
+
+// NewWithHTTPClient creates an IPOContext with a pre-built http.Client (useful for testing).
+func NewWithHTTPClient(httpClient *httplib.Client) *IPOContext {
+	return &IPOContext{httpClient: httpClient}
+}
+
+// NewFromCfg creates an IPOContext from a *config.Config.
+func NewFromCfg(cfg *config.Config) (*IPOContext, error) {
+	httpClient, err := httplib.NewFromCfg(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "create http client error")
+	}
+	return &IPOContext{httpClient: httpClient}, nil
+}
+
+// NewFromEnv returns an IPOContext configured from environment variables.
+func NewFromEnv() (*IPOContext, error) {
+	cfg, err := config.NewFormEnv()
+	if err != nil {
+		return nil, errors.Wrap(err, "load config from env error")
+	}
+	return NewFromCfg(cfg)
+}
+
+// SubmitOrder submits a new IPO subscription order.
+//
+// Reference: POST /v1/openapi/ipo/submit
+func (c *IPOContext) SubmitOrder(ctx context.Context, req *SubmitOrderRequest) (*SubmitOrderResult, error) {
+	body := map[string]interface{}{
+		"symbol":   req.Symbol,
+		"sub_qty":  req.SubQty,
+		"batch_id": req.BatchID,
+		"method":   int32(req.Method),
+	}
+	var resp jsontypes.SubmitOrderResponse
+	if err := c.httpClient.Post(ctx, "/v1/openapi/ipo/submit", body, &resp); err != nil {
+		return nil, err
+	}
+	return convertSubmitOrderResult(&resp), nil
+}
+
+// AmendOrder modifies an existing IPO subscription order.
+//
+// Reference: POST /v1/openapi/ipo/amend
+func (c *IPOContext) AmendOrder(ctx context.Context, req *AmendOrderRequest) (*SubmitOrderResult, error) {
+	body := map[string]interface{}{
+		"symbol":   req.Symbol,
+		"sub_qty":  req.SubQty,
+		"batch_id": req.BatchID,
+		"method":   int32(req.Method),
+		"order_id": req.OrderID,
+	}
+	var resp jsontypes.SubmitOrderResponse
+	if err := c.httpClient.Post(ctx, "/v1/openapi/ipo/amend", body, &resp); err != nil {
+		return nil, err
+	}
+	return convertSubmitOrderResult(&resp), nil
+}
+
+// WithdrawOrder cancels an IPO subscription order.
+//
+// Reference: POST /v1/openapi/ipo/withdraw
+func (c *IPOContext) WithdrawOrder(ctx context.Context, req *WithdrawOrderRequest) (bool, error) {
+	body := map[string]interface{}{
+		"order_id": req.OrderID,
+	}
+	var resp jsontypes.WithdrawOrderResponse
+	if err := c.httpClient.Post(ctx, "/v1/openapi/ipo/withdraw", body, &resp); err != nil {
+		return false, err
+	}
+	return resp.Result, nil
+}
+
+// FetchOrderList returns the IPO subscription order list.
+//
+// Reference: GET /v1/openapi/ipo/order/list
+func (c *IPOContext) FetchOrderList(ctx context.Context, req *FetchOrderListRequest) (orders []*OrderListItem, hasMore bool, err error) {
+	var resp jsontypes.FetchOrderListResponse
+	if err = c.httpClient.Get(ctx, "/v1/openapi/ipo/order/list", req.Values(), &resp); err != nil {
+		return
+	}
+	hasMore = resp.HasMore
+	orders = make([]*OrderListItem, 0, len(resp.List))
+	for _, item := range resp.List {
+		orders = append(orders, convertOrderListItem(item))
+	}
+	return
+}
+
+// FetchOrderDetail returns the full detail of an IPO subscription order.
+//
+// Reference: GET /v1/openapi/ipo/order
+func (c *IPOContext) FetchOrderDetail(ctx context.Context, req *FetchOrderDetailRequest) (*OrderDetail, error) {
+	var resp jsontypes.FetchOrderDetailResponse
+	if err := c.httpClient.Get(ctx, "/v1/openapi/ipo/order", req.Values(), &resp); err != nil {
+		return nil, err
+	}
+	return convertOrderDetail(&resp), nil
+}
+
+// FetchMarginList returns the financing scheme list for an IPO (融资方案列表).
+//
+// Reference: GET /v1/openapi/ipo/margin/list
+func (c *IPOContext) FetchMarginList(ctx context.Context, req *FetchMarginListRequest) ([]*MarginItem, error) {
+	var resp jsontypes.FetchMarginListResponse
+	if err := c.httpClient.Get(ctx, "/v1/openapi/ipo/margin/list", req.Values(), &resp); err != nil {
+		return nil, err
+	}
+	items := make([]*MarginItem, 0, len(resp.List))
+	for _, item := range resp.List {
+		items = append(items, convertMarginItem(item))
+	}
+	return items, nil
+}
+
+// FetchIpoPaymentList returns available lot quantity options and their subscription amounts.
+//
+// Reference: GET /v1/openapi/ipo/payable/list
+func (c *IPOContext) FetchIpoPaymentList(ctx context.Context, req *FetchIpoPaymentListRequest) ([]*PaymentListItem, error) {
+	var resp jsontypes.FetchIpoPaymentListResponse
+	if err := c.httpClient.Get(ctx, "/v1/openapi/ipo/payable/list", req.Values(), &resp); err != nil {
+		return nil, err
+	}
+	items := make([]*PaymentListItem, 0, len(resp.List))
+	for _, item := range resp.List {
+		items = append(items, convertPaymentListItem(item))
+	}
+	return items, nil
+}
+
+// FetchBuyLimit returns the user's buying power for IPO subscription (打新购买力).
+//
+// Reference: GET /v1/openapi/ipo/buylimit
+func (c *IPOContext) FetchBuyLimit(ctx context.Context, req *FetchBuyLimitRequest) (*BuyingPower, error) {
+	var resp jsontypes.FetchBuyLimitResponse
+	if err := c.httpClient.Get(ctx, "/v1/openapi/ipo/buylimit", req.Values(), &resp); err != nil {
+		return nil, err
+	}
+	return &BuyingPower{
+		TotalAmount:   resp.TotalAmount,
+		CurrentAmount: resp.CurrentAmount,
+		MmfAmount:     resp.MmfAmount,
+		CashAmount:    resp.CashAmount,
+	}, nil
+}
+
+// --- internal converters ---
+
+func convertSubmitOrderResult(j *jsontypes.SubmitOrderResponse) *SubmitOrderResult {
+	return &SubmitOrderResult{
+		ID:                j.ID,
+		Name:              j.Name,
+		Symbol:            j.Symbol,
+		Market:            j.Market,
+		SubQty:            j.SubQty,
+		SubAmount:         j.SubAmount,
+		HandingFee:        j.HandingFee,
+		WithdrawAble:      j.WithdrawAble,
+		LotWinQty:         j.LotWinQty,
+		Status:            SubscriptionStatus(j.Status),
+		Currency:          j.Currency,
+		FinancingAmount:   j.FinancingAmount,
+		NeedToPay:         j.NeedToPay,
+		IpoStatus:         j.IpoStatus,
+		Method:            SubscriptionMethod(j.Method),
+		FinancingInterest: j.FinancingInterest,
+		FinanceFeeRate:    j.FinanceFeeRate,
+		IpoPrice:          j.IpoPrice,
+		BorrowAmount:      j.BorrowAmount,
+		BorrowInterest:    j.BorrowInterest,
+		TotalAmount:       j.TotalAmount,
+		CurrentAmount:     j.CurrentAmount,
+		RefundAmount:      j.RefundAmount,
+		LuckAt:            j.LuckAt,
+		IpoDate:           j.IpoDate,
+		MartBegin:         j.MartBegin,
+		MartEnd:           j.MartEnd,
+		RejectText:        j.RejectText,
+		ModifyEnable:      j.ModifyEnable,
+		BatchID:           j.BatchID,
+		BorrowEnable:      j.BorrowEnable,
+		LuckyFee:          j.LuckyFee,
+	}
+}
+
+func convertOrderListItem(j *jsontypes.OrderListItem) *OrderListItem {
+	return &OrderListItem{
+		ID:              j.ID,
+		Name:            j.Name,
+		Symbol:          j.Symbol,
+		Status:          SubscriptionStatus(j.Status),
+		SubQty:          j.SubQty,
+		Method:          SubscriptionMethod(j.Method),
+		CreatedAt:       j.CreatedAt,
+		Currency:        j.Currency,
+		LotWinQty:       j.LotWinQty,
+		SubAmount:       j.SubAmount,
+		CashAmount:      j.CashAmount,
+		FinancingAmount: j.FinancingAmount,
+		FinancingRatio:  j.FinancingRatio,
+		HandingFee:      j.HandingFee,
+	}
+}
+
+func convertOrderDetail(j *jsontypes.FetchOrderDetailResponse) *OrderDetail {
+	return &OrderDetail{
+		ID:                j.ID,
+		Name:              j.Name,
+		Code:              j.Code,
+		Market:            j.Market,
+		SubQty:            j.SubQty,
+		SubAmount:         j.SubAmount,
+		HandingFee:        j.HandingFee,
+		WithdrawAble:      j.WithdrawAble,
+		LotWinQty:         j.LotWinQty,
+		Status:            SubscriptionStatus(j.Status),
+		Currency:          j.Currency,
+		FinancingAmount:   j.FinancingAmount,
+		NeedToPay:         j.NeedToPay,
+		IpoStatus:         j.IpoStatus,
+		Method:            SubscriptionMethod(j.Method),
+		FinancingInterest: j.FinancingInterest,
+		FinanceFeeRate:    j.FinanceFeeRate,
+		Explanation:       j.Explanation,
+		IpoPrice:          j.IpoPrice,
+		BorrowAmount:      j.BorrowAmount,
+		BorrowInterest:    j.BorrowInterest,
+		Symbol:            j.Symbol,
+		TotalAmount:       j.TotalAmount,
+		CurrentAmount:     j.CurrentAmount,
+		RefundAmount:      j.RefundAmount,
+		LuckAt:            j.LuckAt,
+		RejectText:        j.RejectText,
+		Multiple:          j.Multiple,
+		ModifyEnable:      j.ModifyEnable,
+		LuckyFee:          j.LuckyFee,
+		Channel:           j.Channel,
+		BatchID:           j.BatchID,
+	}
+}
+
+func convertMarginItem(j *jsontypes.MarginItem) *MarginItem {
+	return &MarginItem{
+		Method:           SubscriptionMethod(j.Method),
+		HandingFee:       j.HandingFee,
+		Currency:         j.Currency,
+		Deadline:         j.Deadline,
+		Multiple:         j.Multiple,
+		FinancingFeeRate: j.FinancingFeeRate,
+		RemainAmount:     j.RemainAmount,
+		BatchID:          j.BatchID,
+		IsEnded:          j.IsEnded,
+		FinancingRatio:   j.FinancingRatio,
+		StartAt:          j.StartAt,
+		DisplayName:      j.DisplayName,
+		MinCash:          j.MinCash,
+	}
+}
+
+func convertPaymentListItem(j *jsontypes.PaymentListItem) *PaymentListItem {
+	return &PaymentListItem{
+		Number:    j.Number,
+		SubQty:    j.SubQty,
+		SubAmount: j.SubAmount,
+		Currency:  j.Currency,
+	}
+}

--- a/ipo/context_test.go
+++ b/ipo/context_test.go
@@ -1,0 +1,333 @@
+package ipo_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/longbridgeapp/assert"
+
+	httplib "github.com/longbridge/openapi-go/http"
+	"github.com/longbridge/openapi-go/ipo"
+)
+
+// newTestServer starts a mock HTTP server and returns an IPOContext wired to it.
+// handler receives all requests and writes the JSON response body (without envelope).
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*ipo.IPOContext, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		handler(w, r)
+	}))
+	httpClient, err := httplib.New(
+		httplib.WithURL(srv.URL),
+		httplib.WithAppKey("test-key"),
+		httplib.WithAppSecret("test-secret"),
+		httplib.WithAccessToken("test-token"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ipo.NewWithHTTPClient(httpClient), srv
+}
+
+// envelope wraps data in the standard Longbridge API response envelope.
+func envelope(t *testing.T, data interface{}) []byte {
+	t.Helper()
+	inner, _ := json.Marshal(data)
+	out, _ := json.Marshal(map[string]interface{}{
+		"code":    0,
+		"message": "success",
+		"data":    json.RawMessage(inner),
+	})
+	return out
+}
+
+func TestSubmitOrder(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"id":          int64(100001),
+			"name":        "Alibaba",
+			"symbol":      "9988.HK",
+			"market":      "HK",
+			"sub_qty":     "1000",
+			"sub_amount":  "88000.00",
+			"handing_fee": "100.00",
+			"status":      1,
+			"currency":    "HKD",
+			"method":      2,
+			"batch_id":    int64(12345),
+			"modify_enable": true,
+			"withdraw_able": false,
+		}))
+	})
+	defer srv.Close()
+
+	result, err := ctx.SubmitOrder(context.Background(), &ipo.SubmitOrderRequest{
+		Symbol:  "9988.HK",
+		SubQty:  "1000",
+		BatchID: 12345,
+		Method:  2,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(100001), result.ID)
+	assert.Equal(t, "9988.HK", result.Symbol)
+	assert.Equal(t, "HK", result.Market)
+	assert.Equal(t, "1000", result.SubQty)
+	assert.Equal(t, "88000.00", result.SubAmount)
+	assert.Equal(t, "100.00", result.HandingFee)
+	assert.Equal(t, ipo.SubscriptionStatus(1), result.Status)
+	assert.Equal(t, ipo.SubscriptionMethod(2), result.Method)
+	assert.Equal(t, int64(12345), result.BatchID)
+	assert.True(t, result.ModifyEnable)
+	assert.False(t, result.WithdrawAble)
+}
+
+func TestAmendOrder(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"id":      int64(100001),
+			"symbol":  "9988.HK",
+			"sub_qty": "2000",
+			"status":  1,
+			"method":  2,
+		}))
+	})
+	defer srv.Close()
+
+	result, err := ctx.AmendOrder(context.Background(), &ipo.AmendOrderRequest{
+		Symbol:  "9988.HK",
+		SubQty:  "2000",
+		BatchID: 12345,
+		Method:  2,
+		OrderID: 100001,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(100001), result.ID)
+	assert.Equal(t, "2000", result.SubQty)
+	assert.Equal(t, ipo.SubscriptionStatus(1), result.Status)
+	assert.Equal(t, ipo.SubscriptionMethod(2), result.Method)
+}
+
+func TestWithdrawOrder(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{"result": true}))
+	})
+	defer srv.Close()
+
+	ok, err := ctx.WithdrawOrder(context.Background(), &ipo.WithdrawOrderRequest{
+		OrderID: 100001,
+	})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestFetchOrderList(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"list": []map[string]interface{}{
+				{
+					"id":               int64(100001),
+					"name":             "Alibaba",
+					"symbol":           "9988.HK",
+					"status":           2,
+					"sub_qty":          "1000",
+					"method":           1,
+					"created_at":       int64(1700000000),
+					"currency":         "HKD",
+					"lot_win_qty":      "0",
+					"sub_amount":       "88000.00",
+					"cash_amount":      "8800.00",
+					"financing_amount": "79200.00",
+					"financing_ratio":  "0.9",
+					"handing_fee":      "100.00",
+				},
+			},
+			"has_more": true,
+		}))
+	})
+	defer srv.Close()
+
+	orders, hasMore, err := ctx.FetchOrderList(context.Background(), &ipo.FetchOrderListRequest{
+		Symbol:   "9988.HK",
+		Page:     1,
+		PageSize: 10,
+	})
+	assert.NoError(t, err)
+	assert.True(t, hasMore)
+	assert.Equal(t, 1, len(orders))
+
+	o := orders[0]
+	assert.Equal(t, int64(100001), o.ID)
+	assert.Equal(t, "9988.HK", o.Symbol)
+	assert.Equal(t, ipo.SubscriptionStatus(2), o.Status)
+	assert.Equal(t, ipo.SubscriptionMethod(1), o.Method)
+	assert.Equal(t, "1000", o.SubQty)
+	assert.Equal(t, int64(1700000000), o.CreatedAt)
+	assert.Equal(t, "HKD", o.Currency)
+	assert.Equal(t, "88000.00", o.SubAmount)
+	assert.Equal(t, "8800.00", o.CashAmount)
+	assert.Equal(t, "79200.00", o.FinancingAmount)
+	assert.Equal(t, "100.00", o.HandingFee)
+}
+
+func TestFetchOrderDetail(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"id":                int64(100001),
+			"name":              "Alibaba",
+			"code":              "9988",
+			"symbol":            "9988.HK",
+			"market":            "HK",
+			"sub_qty":           "1000",
+			"sub_amount":        "88000.00",
+			"handing_fee":       "100.00",
+			"status":            2,
+			"currency":          "HKD",
+			"method":            1,
+			"total_amount":      "88100.00",
+			"need_to_pay":       "0",
+			"financing_amount":  "0",
+			"ipo_price":         "88.00",
+			"modify_enable":     true,
+			"withdraw_able":     false,
+			"luck_at":           int64(0),
+			"batch_id":          int64(12345),
+			"channel":           "PUBLIC_OFFER",
+		}))
+	})
+	defer srv.Close()
+
+	detail, err := ctx.FetchOrderDetail(context.Background(), &ipo.FetchOrderDetailRequest{
+		OrderID: 100001,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(100001), detail.ID)
+	assert.Equal(t, "9988", detail.Code)
+	assert.Equal(t, "9988.HK", detail.Symbol)
+	assert.Equal(t, "HK", detail.Market)
+	assert.Equal(t, "1000", detail.SubQty)
+	assert.Equal(t, "88000.00", detail.SubAmount)
+	assert.Equal(t, "88100.00", detail.TotalAmount)
+	assert.Equal(t, "88.00", detail.IpoPrice)
+	assert.Equal(t, ipo.SubscriptionStatus(2), detail.Status)
+	assert.Equal(t, ipo.SubscriptionMethod(1), detail.Method)
+	assert.Equal(t, int64(12345), detail.BatchID)
+	assert.Equal(t, "PUBLIC_OFFER", detail.Channel)
+	assert.True(t, detail.ModifyEnable)
+	assert.False(t, detail.WithdrawAble)
+}
+
+func TestFetchMarginList(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"list": []map[string]interface{}{
+				{
+					"method":             1,
+					"handing_fee":        "100.00",
+					"currency":           "HKD",
+					"financing_fee_rate": "0",
+					"remain_amount":      "0",
+					"batch_id":           int64(12345),
+					"is_ended":           false,
+					"display_name":       "Cash",
+					"min_cash":           "10000.00",
+					"start_at":           int64(1699900000),
+					"deadline":           int64(1700000000),
+					"multiple":           "1",
+					"financing_ratio":    "0",
+				},
+				{
+					"method":             2,
+					"handing_fee":        "150.00",
+					"currency":           "HKD",
+					"financing_fee_rate": "0.06",
+					"remain_amount":      "200000.00",
+					"batch_id":           int64(12345),
+					"is_ended":           false,
+					"display_name":       "10x Margin",
+					"min_cash":           "5000.00",
+					"start_at":           int64(1699900000),
+					"deadline":           int64(1700000000),
+					"multiple":           "10",
+					"financing_ratio":    "0.9",
+				},
+			},
+		}))
+	})
+	defer srv.Close()
+
+	margins, err := ctx.FetchMarginList(context.Background(), &ipo.FetchMarginListRequest{
+		Symbol: "9988.HK",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(margins))
+
+	cash := margins[0]
+	assert.Equal(t, ipo.SubscriptionMethod(1), cash.Method)
+	assert.Equal(t, "Cash", cash.DisplayName)
+	assert.Equal(t, "HKD", cash.Currency)
+	assert.Equal(t, "100.00", cash.HandingFee)
+	assert.Equal(t, "10000.00", cash.MinCash)
+	assert.Equal(t, int64(12345), cash.BatchID)
+	assert.Equal(t, int64(1700000000), cash.Deadline)
+	assert.False(t, cash.IsEnded)
+
+	margin := margins[1]
+	assert.Equal(t, ipo.SubscriptionMethod(2), margin.Method)
+	assert.Equal(t, "0.06", margin.FinancingFeeRate)
+	assert.Equal(t, "200000.00", margin.RemainAmount)
+	assert.Equal(t, "10", margin.Multiple)
+}
+
+func TestFetchIpoPaymentList(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"list": []map[string]interface{}{
+				{"number": 1, "sub_qty": "500", "sub_amount": "44000.00", "currency": "HKD"},
+				{"number": 2, "sub_qty": "1000", "sub_amount": "88000.00", "currency": "HKD"},
+				{"number": 3, "sub_qty": "2000", "sub_amount": "176000.00", "currency": "HKD"},
+			},
+		}))
+	})
+	defer srv.Close()
+
+	list, err := ctx.FetchIpoPaymentList(context.Background(), &ipo.FetchIpoPaymentListRequest{
+		Symbol: "9988.HK",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(list))
+
+	assert.Equal(t, int32(1), list[0].Number)
+	assert.Equal(t, "500", list[0].SubQty)
+	assert.Equal(t, "44000.00", list[0].SubAmount)
+	assert.Equal(t, "HKD", list[0].Currency)
+
+	assert.Equal(t, int32(3), list[2].Number)
+	assert.Equal(t, "2000", list[2].SubQty)
+	assert.Equal(t, "176000.00", list[2].SubAmount)
+}
+
+func TestFetchBuyLimit(t *testing.T) {
+	ctx, srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(envelope(t, map[string]interface{}{
+			"total_amount":   "500000.00",
+			"current_amount": "300000.00",
+			"mmf_amount":     "100000.00",
+			"cash_amount":    "200000.00",
+		}))
+	})
+	defer srv.Close()
+
+	bp, err := ctx.FetchBuyLimit(context.Background(), &ipo.FetchBuyLimitRequest{
+		Symbol:   "9988.HK",
+		Currency: "HKD",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "500000.00", bp.TotalAmount)
+	assert.Equal(t, "300000.00", bp.CurrentAmount)
+	assert.Equal(t, "100000.00", bp.MmfAmount)
+	assert.Equal(t, "200000.00", bp.CashAmount)
+}

--- a/ipo/jsontypes/types.go
+++ b/ipo/jsontypes/types.go
@@ -1,0 +1,145 @@
+package jsontypes
+
+// SubmitOrderResponse is the JSON response for submit/amend IPO order.
+type SubmitOrderResponse struct {
+	ID                int64  `json:"id"`
+	Name              string `json:"name"`
+	Symbol            string `json:"symbol"`
+	Market            string `json:"market"`
+	SubQty            string `json:"sub_qty"`
+	SubAmount         string `json:"sub_amount"`
+	HandingFee        string `json:"handing_fee"`
+	WithdrawAble      bool   `json:"withdraw_able"`
+	LotWinQty         string `json:"lot_win_qty"`
+	Status            int32  `json:"status"`
+	Currency          string `json:"currency"`
+	FinancingAmount   string `json:"financing_amount"`
+	NeedToPay         string `json:"need_to_pay"`
+	IpoStatus         int32  `json:"ipo_status"`
+	Method            int32  `json:"method"`
+	FinancingInterest string `json:"financing_interest"`
+	FinanceFeeRate    string `json:"finance_fee_rate"`
+	IpoPrice          string `json:"ipo_price"`
+	BorrowAmount      string `json:"borrow_amount"`
+	BorrowInterest    string `json:"borrow_interest"`
+	TotalAmount       string `json:"total_amount"`
+	CurrentAmount     string `json:"current_amount"`
+	RefundAmount      string `json:"refund_amount"`
+	LuckAt            int64  `json:"luck_at"`
+	IpoDate           int64  `json:"ipo_date"`
+	MartBegin         int64  `json:"mart_begin"`
+	MartEnd           int64  `json:"mart_end"`
+	RejectText        string `json:"reject_text"`
+	ModifyEnable      bool   `json:"modify_enable"`
+	BatchID           int64  `json:"batch_id"`
+	BorrowEnable      bool   `json:"borrow_enable"`
+	LuckyFee          string `json:"lucky_fee"`
+}
+
+// WithdrawOrderResponse is the JSON response for withdraw IPO order.
+type WithdrawOrderResponse struct {
+	Result bool `json:"result"`
+}
+
+// OrderListItem is one item in the IPO order list.
+type OrderListItem struct {
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	Symbol          string `json:"symbol"`
+	Status          int32  `json:"status"`
+	SubQty          string `json:"sub_qty"`
+	Method          int32  `json:"method"`
+	CreatedAt       int64  `json:"created_at"`
+	Currency        string `json:"currency"`
+	LotWinQty       string `json:"lot_win_qty"`
+	SubAmount       string `json:"sub_amount"`
+	CashAmount      string `json:"cash_amount"`
+	FinancingAmount string `json:"financing_amount"`
+	FinancingRatio  string `json:"financing_ratio"`
+	HandingFee      string `json:"handing_fee"`
+}
+
+// FetchOrderListResponse is the JSON response for order list.
+type FetchOrderListResponse struct {
+	List    []*OrderListItem `json:"list"`
+	HasMore bool             `json:"has_more"`
+}
+
+// FetchOrderDetailResponse is the JSON response for order detail.
+type FetchOrderDetailResponse struct {
+	ID                int64  `json:"id"`
+	Name              string `json:"name"`
+	Code              string `json:"code"`
+	Market            string `json:"market"`
+	SubQty            string `json:"sub_qty"`
+	SubAmount         string `json:"sub_amount"`
+	HandingFee        string `json:"handing_fee"`
+	WithdrawAble      bool   `json:"withdraw_able"`
+	LotWinQty         string `json:"lot_win_qty"`
+	Status            int32  `json:"status"`
+	Currency          string `json:"currency"`
+	FinancingAmount   string `json:"financing_amount"`
+	NeedToPay         string `json:"need_to_pay"`
+	IpoStatus         int32  `json:"ipo_status"`
+	Method            int32  `json:"method"`
+	FinancingInterest string `json:"financing_interest"`
+	FinanceFeeRate    string `json:"finance_fee_rate"`
+	Explanation       string `json:"explanation"`
+	IpoPrice          string `json:"ipo_price"`
+	BorrowAmount      string `json:"borrow_amount"`
+	BorrowInterest    string `json:"borrow_interest"`
+	Symbol            string `json:"symbol"`
+	TotalAmount       string `json:"total_amount"`
+	CurrentAmount     string `json:"current_amount"`
+	RefundAmount      string `json:"refund_amount"`
+	LuckAt            int64  `json:"luck_at"`
+	RejectText        string `json:"reject_text"`
+	Multiple          string `json:"multiple"`
+	ModifyEnable      bool   `json:"modify_enable"`
+	LuckyFee          string `json:"lucky_fee"`
+	Channel           string `json:"channel"`
+	BatchID           int64  `json:"batch_id"`
+}
+
+// MarginItem is one financing scheme item.
+type MarginItem struct {
+	Method           int32  `json:"method"`
+	HandingFee       string `json:"handing_fee"`
+	Currency         string `json:"currency"`
+	Deadline         int64  `json:"deadline"`
+	Multiple         string `json:"multiple"`
+	FinancingFeeRate string `json:"financing_fee_rate"`
+	RemainAmount     string `json:"remain_amount"`
+	BatchID          int64  `json:"batch_id"`
+	IsEnded          bool   `json:"is_ended"`
+	FinancingRatio   string `json:"financing_ratio"`
+	StartAt          int64  `json:"start_at"`
+	DisplayName      string `json:"display_name"`
+	MinCash          string `json:"min_cash"`
+}
+
+// FetchMarginListResponse is the JSON response for margin/financing scheme list.
+type FetchMarginListResponse struct {
+	List []*MarginItem `json:"list"`
+}
+
+// PaymentListItem is one item in the IPO payment/lot list.
+type PaymentListItem struct {
+	Number    int32  `json:"number"`
+	SubQty    string `json:"sub_qty"`
+	SubAmount string `json:"sub_amount"`
+	Currency  string `json:"currency"`
+}
+
+// FetchIpoPaymentListResponse is the JSON response for IPO payment list.
+type FetchIpoPaymentListResponse struct {
+	List []*PaymentListItem `json:"list"`
+}
+
+// FetchBuyLimitResponse is the JSON response for buying power.
+type FetchBuyLimitResponse struct {
+	TotalAmount   string `json:"total_amount"`
+	CurrentAmount string `json:"current_amount"`
+	MmfAmount     string `json:"mmf_amount"`
+	CashAmount    string `json:"cash_amount"`
+}

--- a/ipo/request_values.go
+++ b/ipo/request_values.go
@@ -1,0 +1,66 @@
+package ipo
+
+import (
+	"net/url"
+	"strconv"
+)
+
+
+// Values converts FetchOrderListRequest to URL query parameters.
+func (req *FetchOrderListRequest) Values() url.Values {
+	if req == nil {
+		return url.Values{}
+	}
+	v := url.Values{}
+	if req.Symbol != "" {
+		v.Set("symbol", req.Symbol)
+	}
+	if req.Page != 0 {
+		v.Set("page", strconv.Itoa(int(req.Page)))
+	}
+	if req.PageSize != 0 {
+		v.Set("page_size", strconv.Itoa(int(req.PageSize)))
+	}
+	return v
+}
+
+// Values converts FetchOrderDetailRequest to URL query parameters.
+func (req *FetchOrderDetailRequest) Values() url.Values {
+	if req == nil {
+		return url.Values{}
+	}
+	v := url.Values{}
+	v.Set("order_id", strconv.FormatInt(req.OrderID, 10))
+	return v
+}
+
+// Values converts FetchMarginListRequest to URL query parameters.
+func (req *FetchMarginListRequest) Values() url.Values {
+	if req == nil {
+		return url.Values{}
+	}
+	v := url.Values{}
+	v.Set("symbol", req.Symbol)
+	return v
+}
+
+// Values converts FetchIpoPaymentListRequest to URL query parameters.
+func (req *FetchIpoPaymentListRequest) Values() url.Values {
+	if req == nil {
+		return url.Values{}
+	}
+	v := url.Values{}
+	v.Set("symbol", req.Symbol)
+	return v
+}
+
+// Values converts FetchBuyLimitRequest to URL query parameters.
+func (req *FetchBuyLimitRequest) Values() url.Values {
+	if req == nil {
+		return url.Values{}
+	}
+	v := url.Values{}
+	v.Set("symbol", req.Symbol)
+	v.Set("currency", req.Currency)
+	return v
+}

--- a/ipo/types.go
+++ b/ipo/types.go
@@ -1,0 +1,180 @@
+package ipo
+
+// SubscriptionMethod represents the IPO subscription method/channel (认购方式).
+type SubscriptionMethod int32
+
+// SubscriptionStatus represents the order status of an IPO subscription.
+type SubscriptionStatus int32
+
+// SubmitOrderResult is the result returned by SubmitOrder and AmendOrder.
+type SubmitOrderResult struct {
+	ID                int64
+	Name              string
+	Symbol            string
+	Market            string
+	SubQty            string // 申购数量
+	SubAmount         string // 申购金额
+	HandingFee        string // 申购手续费
+	WithdrawAble      bool   // 能否撤单
+	LotWinQty         string // 中签数量
+	Status            SubscriptionStatus
+	Currency          string
+	FinancingAmount   string
+	NeedToPay         string             // 需补缴
+	IpoStatus         int32
+	Method            SubscriptionMethod // 认购方式
+	FinancingInterest string             // 融资利息
+	FinanceFeeRate    string             // 融资利率
+	IpoPrice          string
+	BorrowAmount      string
+	BorrowInterest    string
+	TotalAmount       string // 合计金额
+	CurrentAmount     string // 当前币种现金（港币现金）
+	RefundAmount      string // 需退款金额
+	LuckAt            int64
+	IpoDate           int64  // 上市时间
+	MartBegin         int64  // 暗盘开始时间
+	MartEnd           int64  // 暗盘结束时间
+	RejectText        string // 拒绝理由
+	ModifyEnable      bool   // 是否能够改单
+	BatchID           int64
+	BorrowEnable      bool   // 是否支持借币
+	LuckyFee          string
+}
+
+// OrderListItem is a summary item in the IPO order list.
+type OrderListItem struct {
+	ID              int64
+	Name            string
+	Symbol          string
+	Status          SubscriptionStatus
+	SubQty          string
+	Method          SubscriptionMethod
+	CreatedAt       int64
+	Currency        string
+	LotWinQty       string
+	SubAmount       string
+	CashAmount      string
+	FinancingAmount string
+	FinancingRatio  string
+	HandingFee      string
+}
+
+// OrderDetail is the full detail of an IPO subscription order.
+type OrderDetail struct {
+	ID                int64
+	Name              string
+	Code              string
+	Market            string
+	SubQty            string // 申购数量
+	SubAmount         string // 申购金额
+	HandingFee        string // 申购手续费
+	WithdrawAble      bool   // 能否撤单
+	LotWinQty         string // 中签数量
+	Status            SubscriptionStatus
+	Currency          string
+	FinancingAmount   string
+	NeedToPay         string             // 需补缴
+	IpoStatus         int32
+	Method            SubscriptionMethod // 认购方式
+	FinancingInterest string             // 融资利息
+	FinanceFeeRate    string             // 融资利率
+	Explanation       string             // 需补缴文案
+	IpoPrice          string
+	BorrowAmount      string
+	BorrowInterest    string
+	Symbol            string
+	TotalAmount       string // 合计金额
+	CurrentAmount     string // 当前币种现金（港币现金）
+	RefundAmount      string // 需退款金额
+	LuckAt            int64
+	RejectText        string // 拒绝理由
+	Multiple          string
+	ModifyEnable      bool   // 是否能够改单
+	LuckyFee          string
+	Channel           string
+	BatchID           int64
+}
+
+// MarginItem is a financing scheme for an IPO (融资方案).
+type MarginItem struct {
+	Method           SubscriptionMethod
+	HandingFee       string
+	Currency         string
+	Deadline         int64
+	Multiple         string
+	FinancingFeeRate string
+	RemainAmount     string
+	BatchID          int64
+	IsEnded          bool
+	FinancingRatio   string
+	StartAt          int64
+	DisplayName      string
+	MinCash          string
+}
+
+// PaymentListItem is one selectable lot quantity and its subscription amount.
+type PaymentListItem struct {
+	Number    int32  // lot number option
+	SubQty    string // subscription quantity
+	SubAmount string
+	Currency  string
+}
+
+// BuyingPower contains the user's available funds for IPO subscription (打新购买力).
+type BuyingPower struct {
+	TotalAmount   string
+	CurrentAmount string // 当前币种现金（港币现金）
+	MmfAmount     string
+	CashAmount    string
+}
+
+// SubmitOrderRequest contains parameters for submitting an IPO subscription order.
+type SubmitOrderRequest struct {
+	Symbol  string             // required
+	SubQty  string             // required, subscription quantity
+	BatchID int64              // required
+	Method  SubscriptionMethod // required, subscription method
+}
+
+// AmendOrderRequest contains parameters for modifying an IPO subscription order.
+type AmendOrderRequest struct {
+	Symbol  string             // required
+	SubQty  string             // required
+	BatchID int64              // required
+	Method  SubscriptionMethod // required
+	OrderID int64              // required
+}
+
+// WithdrawOrderRequest contains parameters for cancelling an IPO subscription.
+type WithdrawOrderRequest struct {
+	OrderID int64 // required
+}
+
+// FetchOrderListRequest contains parameters for querying IPO order list.
+type FetchOrderListRequest struct {
+	Symbol   string // optional
+	Page     int32  // optional
+	PageSize int32  // optional
+}
+
+// FetchOrderDetailRequest contains parameters for querying IPO order detail.
+type FetchOrderDetailRequest struct {
+	OrderID int64 // required
+}
+
+// FetchMarginListRequest contains parameters for querying financing schemes.
+type FetchMarginListRequest struct {
+	Symbol string // required
+}
+
+// FetchIpoPaymentListRequest contains parameters for querying lot quantity options.
+type FetchIpoPaymentListRequest struct {
+	Symbol string // required
+}
+
+// FetchBuyLimitRequest contains parameters for querying buying power.
+type FetchBuyLimitRequest struct {
+	Symbol   string // required
+	Currency string // required
+}


### PR DESCRIPTION
1. 提交申购订单；
2. 修改IPO申购订单；
3. 撤销IPO申请；
4. 获取订单详情；
5. 查询IPO历史订单；
6. 查詢申购股数单位等限制；
7. 查詢IPO认购方式及费率方案；
8. 获取用户购买力数据；