### PR TITLE
feat(fundamental): add business-segments, institution-rating-views, industry-rank, industry-peers, financial-report-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Go:** Six new `FundamentalContext` methods:
+  - `BusinessSegments` — GET `/v1/quote/fundamentals/business-segments`: latest business segment breakdown.
+  - `BusinessSegmentsHistory` — GET `/v1/quote/fundamentals/business-segments/history`: historical business and regional segment breakdowns with optional `report` and `cate` filters.
+  - `InstitutionRatingViews` — GET `/v1/quote/ratings/institutional`: historical rating distribution time-series (buy/over/hold/under/sell per date).
+  - `IndustryRank` — GET `/v1/quote/industry/rank`: industry leaderboard; exposes `IndustryRankIndicator` and `IndustryRankSortType` enum constants.
+  - `IndustryPeers` — GET `/v1/quote/industries/peers`: recursive industry peer chain; accepts both symbol-style (`AAPL.US`) and raw counter IDs (`BK/US/123`).
+  - `FinancialReportSnapshot` — GET `/v1/quote/financials/earnings-snapshot`: earnings snapshot with forecast and reported metrics.
+
 ## [v4.1.0] - 2026-05-14
 
 ### Added

--- a/cmd/test_new_apis/main.go
+++ b/cmd/test_new_apis/main.go
@@ -236,9 +236,9 @@ func main() {
 	}
 
 	// ══════════════════════════════════════════════════════════
-	// fundamental (26 methods)
+	// fundamental (20 methods)
 	// ══════════════════════════════════════════════════════════
-	fmt.Println("\n=== fundamental.FundamentalContext (26 methods) ===")
+	fmt.Println("\n=== fundamental.FundamentalContext (20 methods) ===")
 	fundCtx, err := fundamental.NewFromCfg(cfg)
 	if err != nil {
 		log.Printf("fundamental.NewFromCfg: %v", err)
@@ -372,72 +372,6 @@ func main() {
 		t.check("Ratings(AAPL.US)", func() error {
 			_, err := fundCtx.Ratings(ctx, sym)
 			return err
-		})
-		// ── new APIs (PR #91) ──────────────────────────────────
-		t.check("BusinessSegments(AAPL.US)", func() error {
-			r, err := fundCtx.BusinessSegments(ctx, sym)
-			if err != nil {
-				return err
-			}
-			fmt.Printf(" (%d segments)", len(r.Business))
-			return nil
-		})
-		t.check("BusinessSegmentsHistory(AAPL.US, qf, \"\")", func() error {
-			r, err := fundCtx.BusinessSegmentsHistory(ctx, sym, "qf", "")
-			if err != nil {
-				return err
-			}
-			fmt.Printf(" (%d periods)", len(r.Historical))
-			return nil
-		})
-		t.check("InstitutionRatingViews(AAPL.US)", func() error {
-			r, err := fundCtx.InstitutionRatingViews(ctx, sym)
-			if err != nil {
-				return err
-			}
-			fmt.Printf(" (%d months)", len(r.Elist))
-			return nil
-		})
-		var bkCounterID string
-		t.check("IndustryRank(US, Indicator0/leading-gainer, Ascending, 10)", func() error {
-			r, err := fundCtx.IndustryRank(ctx, "US", fundamental.IndustryRankIndicator0, fundamental.IndustryRankSortTypeAscending, 10)
-			if err != nil {
-				return err
-			}
-			n := 0
-			for _, g := range r.Items {
-				n += len(g.Lists)
-				for _, item := range g.Lists {
-					if bkCounterID == "" && item.CounterID != "" {
-						bkCounterID = item.CounterID
-					}
-				}
-			}
-			fmt.Printf(" (%d industries, first_id:%s)", n, bkCounterID)
-			return nil
-		})
-		t.check("IndustryPeers(BK/US/..., US, \"\")", func() error {
-			if bkCounterID == "" {
-				bkCounterID = "BK/US/IN00258" // fallback
-			}
-			r, err := fundCtx.IndustryPeers(ctx, bkCounterID, "US", "")
-			if err != nil {
-				return err
-			}
-			children := 0
-			if r.Chain != nil {
-				children = len(r.Chain.Next)
-			}
-			fmt.Printf(" (top:%s children:%d)", r.Top.Name, children)
-			return nil
-		})
-		t.check("FinancialReportSnapshot(AAPL.US)", func() error {
-			r, err := fundCtx.FinancialReportSnapshot(ctx, sym, "", 0, "")
-			if err != nil {
-				return err
-			}
-			fmt.Printf(" (%s %s–%s)", r.Ticker, r.FpStart, r.FpEnd)
-			return nil
 		})
 	}
 

--- a/cmd/test_new_apis/main.go
+++ b/cmd/test_new_apis/main.go
@@ -236,9 +236,9 @@ func main() {
 	}
 
 	// ══════════════════════════════════════════════════════════
-	// fundamental (20 methods)
+	// fundamental (26 methods)
 	// ══════════════════════════════════════════════════════════
-	fmt.Println("\n=== fundamental.FundamentalContext (20 methods) ===")
+	fmt.Println("\n=== fundamental.FundamentalContext (26 methods) ===")
 	fundCtx, err := fundamental.NewFromCfg(cfg)
 	if err != nil {
 		log.Printf("fundamental.NewFromCfg: %v", err)
@@ -372,6 +372,72 @@ func main() {
 		t.check("Ratings(AAPL.US)", func() error {
 			_, err := fundCtx.Ratings(ctx, sym)
 			return err
+		})
+		// ── new APIs (PR #91) ──────────────────────────────────
+		t.check("BusinessSegments(AAPL.US)", func() error {
+			r, err := fundCtx.BusinessSegments(ctx, sym)
+			if err != nil {
+				return err
+			}
+			fmt.Printf(" (%d segments)", len(r.Business))
+			return nil
+		})
+		t.check("BusinessSegmentsHistory(AAPL.US, qf, \"\")", func() error {
+			r, err := fundCtx.BusinessSegmentsHistory(ctx, sym, "qf", "")
+			if err != nil {
+				return err
+			}
+			fmt.Printf(" (%d periods)", len(r.Historical))
+			return nil
+		})
+		t.check("InstitutionRatingViews(AAPL.US)", func() error {
+			r, err := fundCtx.InstitutionRatingViews(ctx, sym)
+			if err != nil {
+				return err
+			}
+			fmt.Printf(" (%d months)", len(r.Elist))
+			return nil
+		})
+		var bkCounterID string
+		t.check("IndustryRank(US, Indicator0/leading-gainer, Ascending, 10)", func() error {
+			r, err := fundCtx.IndustryRank(ctx, "US", fundamental.IndustryRankIndicator0, fundamental.IndustryRankSortTypeAscending, 10)
+			if err != nil {
+				return err
+			}
+			n := 0
+			for _, g := range r.Items {
+				n += len(g.Lists)
+				for _, item := range g.Lists {
+					if bkCounterID == "" && item.CounterID != "" {
+						bkCounterID = item.CounterID
+					}
+				}
+			}
+			fmt.Printf(" (%d industries, first_id:%s)", n, bkCounterID)
+			return nil
+		})
+		t.check("IndustryPeers(BK/US/..., US, \"\")", func() error {
+			if bkCounterID == "" {
+				bkCounterID = "BK/US/IN00258" // fallback
+			}
+			r, err := fundCtx.IndustryPeers(ctx, bkCounterID, "US", "")
+			if err != nil {
+				return err
+			}
+			children := 0
+			if r.Chain != nil {
+				children = len(r.Chain.Next)
+			}
+			fmt.Printf(" (top:%s children:%d)", r.Top.Name, children)
+			return nil
+		})
+		t.check("FinancialReportSnapshot(AAPL.US)", func() error {
+			r, err := fundCtx.FinancialReportSnapshot(ctx, sym, "", 0, "")
+			if err != nil {
+				return err
+			}
+			fmt.Printf(" (%s %s–%s)", r.Ticker, r.FpStart, r.FpEnd)
+			return nil
 		})
 	}
 

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1117,3 +1117,305 @@ func parseTimestampNumber(n json.Number) int64 {
 	v, _ := strconv.ParseInt(s, 10, 64)
 	return v
 }
+
+// ─── BusinessSegments ─────────────────────────────────────────────────────
+
+// BusinessSegments fetches the latest business segment breakdown for a security.
+//
+// Path: GET /v1/quote/fundamentals/business-segments
+func (c *FundamentalContext) BusinessSegments(
+	ctx context.Context,
+	symbol string,
+) (*BusinessSegments, error) {
+	q := url.Values{}
+	q.Set("counter_id", symbolToCounterID(symbol))
+	var resp jsontypes.BusinessSegments
+	if err := c.httpClient.Get(ctx, "/v1/quote/fundamentals/business-segments", q, &resp); err != nil {
+		return nil, err
+	}
+	return convertBusinessSegments(&resp), nil
+}
+
+// BusinessSegmentsHistory fetches historical business segment breakdowns for a
+// security.
+//
+// Path: GET /v1/quote/fundamentals/business-segments/history
+func (c *FundamentalContext) BusinessSegmentsHistory(
+	ctx context.Context,
+	symbol string,
+	report string,
+	cate string,
+) (*BusinessSegmentsHistory, error) {
+	q := url.Values{}
+	q.Set("counter_id", symbolToCounterID(symbol))
+	if report != "" {
+		q.Set("report", report)
+	}
+	if cate != "" {
+		q.Set("cate", cate)
+	}
+	var resp jsontypes.BusinessSegmentsHistory
+	if err := c.httpClient.Get(ctx, "/v1/quote/fundamentals/business-segments/history", q, &resp); err != nil {
+		return nil, err
+	}
+	return convertBusinessSegmentsHistory(&resp), nil
+}
+
+// ─── InstitutionRatingViews ───────────────────────────────────────────────
+
+// InstitutionRatingViews fetches historical institutional rating views for a
+// security.
+//
+// Path: GET /v1/quote/ratings/institutional
+func (c *FundamentalContext) InstitutionRatingViews(
+	ctx context.Context,
+	symbol string,
+) (*InstitutionRatingViews, error) {
+	q := url.Values{}
+	q.Set("counter_id", symbolToCounterID(symbol))
+	var resp jsontypes.InstitutionRatingViews
+	if err := c.httpClient.Get(ctx, "/v1/quote/ratings/institutional", q, &resp); err != nil {
+		return nil, err
+	}
+	return convertInstitutionRatingViews(&resp), nil
+}
+
+// ─── IndustryRank ─────────────────────────────────────────────────────────
+
+// IndustryRank fetches the industry rank for a market.
+//
+// Path: GET /v1/quote/industry/rank
+//
+// indicator is an IndustryRankIndicator constant ("0"–"7").
+// sortType is an IndustryRankSortType constant ("0" ascending, "1" descending).
+func (c *FundamentalContext) IndustryRank(
+	ctx context.Context,
+	market string,
+	indicator IndustryRankIndicator,
+	sortType IndustryRankSortType,
+	limit int,
+) (*IndustryRankResponse, error) {
+	q := url.Values{}
+	q.Set("market", market)
+	q.Set("indicator", string(indicator))
+	q.Set("sort_type", string(sortType))
+	q.Set("limit", strconv.Itoa(limit))
+	var resp jsontypes.IndustryRankResponse
+	if err := c.httpClient.Get(ctx, "/v1/quote/industry/rank", q, &resp); err != nil {
+		return nil, err
+	}
+	return convertIndustryRankResponse(&resp), nil
+}
+
+// ─── IndustryPeers ────────────────────────────────────────────────────────
+
+// IndustryPeers fetches the industry peer chain for a security or industry.
+//
+// Path: GET /v1/quote/industries/peers
+//
+// counterID may be a regular symbol like "AAPL.US" (auto-converted) or an
+// industry counter ID like "BK/US/123" (passed through as-is when it contains
+// a "/").
+func (c *FundamentalContext) IndustryPeers(
+	ctx context.Context,
+	counterID string,
+	market string,
+	industryID string,
+) (*IndustryPeersResponse, error) {
+	// pass industry counter IDs (BK/xx/xx, IN/xx/xx, etc.) through as-is
+	cid := counterID
+	if !strings.Contains(counterID, "/") {
+		cid = symbolToCounterID(counterID)
+	}
+	q := url.Values{}
+	q.Set("type", "1")
+	q.Set("market", market)
+	q.Set("industry_id", industryID)
+	q.Set("counter_id", cid)
+	var resp jsontypes.IndustryPeersResponse
+	if err := c.httpClient.Get(ctx, "/v1/quote/industries/peers", q, &resp); err != nil {
+		return nil, err
+	}
+	return convertIndustryPeersResponse(&resp), nil
+}
+
+// ─── FinancialReportSnapshot ──────────────────────────────────────────────
+
+// FinancialReportSnapshot fetches a financial report snapshot (earnings
+// snapshot) for a security.
+//
+// Path: GET /v1/quote/financials/earnings-snapshot
+func (c *FundamentalContext) FinancialReportSnapshot(
+	ctx context.Context,
+	symbol string,
+	report string,
+	fiscalYear int,
+	fiscalPeriod string,
+) (*FinancialReportSnapshot, error) {
+	q := url.Values{}
+	q.Set("counter_id", symbolToCounterID(symbol))
+	if report != "" {
+		q.Set("report", report)
+	}
+	if fiscalYear != 0 {
+		q.Set("fiscal_year", strconv.Itoa(fiscalYear))
+	}
+	if fiscalPeriod != "" {
+		q.Set("fiscal_period", fiscalPeriod)
+	}
+	var resp jsontypes.FinancialReportSnapshot
+	if err := c.httpClient.Get(ctx, "/v1/quote/financials/earnings-snapshot", q, &resp); err != nil {
+		return nil, err
+	}
+	return convertFinancialReportSnapshot(&resp), nil
+}
+
+// ─── new converters ───────────────────────────────────────────────────────
+
+func convertBusinessSegments(j *jsontypes.BusinessSegments) *BusinessSegments {
+	items := make([]BusinessSegmentItem, 0, len(j.Business))
+	for _, b := range j.Business {
+		items = append(items, BusinessSegmentItem{Name: b.Name, Percent: b.Percent})
+	}
+	return &BusinessSegments{
+		Date:     j.Date,
+		Total:    j.Total,
+		Currency: j.Currency,
+		Business: items,
+	}
+}
+
+func convertBusinessSegmentHistoryItems(js []jsontypes.BusinessSegmentHistoryItem) []BusinessSegmentHistoryItem {
+	out := make([]BusinessSegmentHistoryItem, 0, len(js))
+	for _, b := range js {
+		out = append(out, BusinessSegmentHistoryItem{Name: b.Name, Percent: b.Percent, Value: b.Value})
+	}
+	return out
+}
+
+func convertBusinessSegmentsHistory(j *jsontypes.BusinessSegmentsHistory) *BusinessSegmentsHistory {
+	items := make([]BusinessSegmentsHistoricalItem, 0, len(j.Historical))
+	for _, h := range j.Historical {
+		items = append(items, BusinessSegmentsHistoricalItem{
+			Date:      h.Date,
+			Total:     h.Total,
+			Currency:  h.Currency,
+			Business:  convertBusinessSegmentHistoryItems(h.Business),
+			Regionals: convertBusinessSegmentHistoryItems(h.Regionals),
+		})
+	}
+	return &BusinessSegmentsHistory{Historical: items}
+}
+
+func convertInstitutionRatingViews(j *jsontypes.InstitutionRatingViews) *InstitutionRatingViews {
+	items := make([]InstitutionRatingViewItem, 0, len(j.Elist))
+	for _, e := range j.Elist {
+		items = append(items, InstitutionRatingViewItem{
+			Date:  time.Unix(parseTimestampNumber(e.Date), 0).UTC(),
+			Buy:   e.Buy,
+			Over:  e.Over,
+			Hold:  e.Hold,
+			Under: e.Under,
+			Sell:  e.Sell,
+			Total: e.Total,
+		})
+	}
+	return &InstitutionRatingViews{Elist: items}
+}
+
+func convertIndustryRankResponse(j *jsontypes.IndustryRankResponse) *IndustryRankResponse {
+	groups := make([]IndustryRankGroup, 0, len(j.Items))
+	for _, g := range j.Items {
+		items := make([]IndustryRankItem, 0, len(g.Lists))
+		for _, it := range g.Lists {
+			items = append(items, IndustryRankItem{
+				Name:          it.Name,
+				CounterID:     it.CounterID,
+				Chg:           it.Chg,
+				LeadingName:   it.LeadingName,
+				LeadingTicker: it.LeadingTicker,
+				LeadingChg:    it.LeadingChg,
+				ValueName:     it.ValueName,
+				ValueData:     it.ValueData,
+			})
+		}
+		groups = append(groups, IndustryRankGroup{Lists: items})
+	}
+	return &IndustryRankResponse{Items: groups}
+}
+
+func convertIndustryPeerNode(j *jsontypes.IndustryPeerNode) *IndustryPeerNode {
+	if j == nil {
+		return nil
+	}
+	next := make([]IndustryPeerNode, 0, len(j.Next))
+	for i := range j.Next {
+		if converted := convertIndustryPeerNode(&j.Next[i]); converted != nil {
+			next = append(next, *converted)
+		}
+	}
+	return &IndustryPeerNode{
+		Name:      j.Name,
+		CounterID: j.CounterID,
+		StockNum:  j.StockNum,
+		Chg:       j.Chg,
+		YtdChg:    j.YtdChg,
+		Next:      next,
+	}
+}
+
+func convertIndustryPeersResponse(j *jsontypes.IndustryPeersResponse) *IndustryPeersResponse {
+	return &IndustryPeersResponse{
+		Top: IndustryPeersTop{
+			Name:   j.Top.Name,
+			Market: j.Top.Market,
+		},
+		Chain: convertIndustryPeerNode(j.Chain),
+	}
+}
+
+func convertSnapshotForecastMetric(j *jsontypes.SnapshotForecastMetric) *SnapshotForecastMetric {
+	if j == nil {
+		return nil
+	}
+	return &SnapshotForecastMetric{
+		Value:    j.Value,
+		Yoy:      j.Yoy,
+		CmpDesc:  j.CmpDesc,
+		EstValue: j.EstValue,
+	}
+}
+
+func convertSnapshotReportedMetric(j *jsontypes.SnapshotReportedMetric) *SnapshotReportedMetric {
+	if j == nil {
+		return nil
+	}
+	return &SnapshotReportedMetric{Value: j.Value, Yoy: j.Yoy}
+}
+
+func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *FinancialReportSnapshot {
+	return &FinancialReportSnapshot{
+		Name:              j.Name,
+		Ticker:            j.Ticker,
+		FpStart:           j.FpStart,
+		FpEnd:             j.FpEnd,
+		Currency:          j.Currency,
+		ReportDesc:        j.ReportDesc,
+		FoRevenue:         convertSnapshotForecastMetric(j.FoRevenue),
+		FoEbit:            convertSnapshotForecastMetric(j.FoEbit),
+		FoEps:             convertSnapshotForecastMetric(j.FoEps),
+		FrRevenue:         convertSnapshotReportedMetric(j.FrRevenue),
+		FrProfit:          convertSnapshotReportedMetric(j.FrProfit),
+		FrOperateCash:     convertSnapshotReportedMetric(j.FrOperateCash),
+		FrInvestCash:      convertSnapshotReportedMetric(j.FrInvestCash),
+		FrFinanceCash:     convertSnapshotReportedMetric(j.FrFinanceCash),
+		FrTotalAssets:     convertSnapshotReportedMetric(j.FrTotalAssets),
+		FrTotalLiability:  convertSnapshotReportedMetric(j.FrTotalLiability),
+		FrRoeTtm:          j.FrRoeTtm,
+		FrProfitMargin:    j.FrProfitMargin,
+		FrProfitMarginTtm: j.FrProfitMarginTtm,
+		FrAssetTurnTtm:    j.FrAssetTurnTtm,
+		FrLeverageTtm:     j.FrLeverageTtm,
+		FrDebtAssetsRatio: j.FrDebtAssetsRatio,
+	}
+}

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -586,3 +586,154 @@ type RatingLeafIndicator struct {
 	Score     json.RawMessage `json:"score"`
 	Letter    string          `json:"letter"`
 }
+
+// ── business_segments ─────────────────────────────────────────────
+
+// BusinessSegments is the raw response for
+// GET /v1/quote/fundamentals/business-segments.
+type BusinessSegments struct {
+	Date     string                `json:"date"`
+	Total    string                `json:"total"`
+	Currency string                `json:"currency"`
+	Business []BusinessSegmentItem `json:"business"`
+}
+
+// BusinessSegmentItem is one business segment entry (latest snapshot).
+type BusinessSegmentItem struct {
+	Name    string `json:"name"`
+	Percent string `json:"percent"`
+}
+
+// BusinessSegmentsHistory is the raw response for
+// GET /v1/quote/fundamentals/business-segments/history.
+type BusinessSegmentsHistory struct {
+	Historical []BusinessSegmentsHistoricalItem `json:"historical"`
+}
+
+// BusinessSegmentsHistoricalItem is one historical business segments snapshot.
+type BusinessSegmentsHistoricalItem struct {
+	Date      string                        `json:"date"`
+	Total     string                        `json:"total"`
+	Currency  string                        `json:"currency"`
+	Business  []BusinessSegmentHistoryItem  `json:"business"`
+	Regionals []BusinessSegmentHistoryItem  `json:"regionals"`
+}
+
+// BusinessSegmentHistoryItem is one business/regional segment entry in a
+// historical snapshot.
+type BusinessSegmentHistoryItem struct {
+	Name    string `json:"name"`
+	Percent string `json:"percent"`
+	Value   string `json:"value"`
+}
+
+// ── institution_rating_views ──────────────────────────────────────
+
+// InstitutionRatingViews is the raw response for
+// GET /v1/quote/ratings/institutional.
+type InstitutionRatingViews struct {
+	Elist []InstitutionRatingViewItem `json:"elist"`
+}
+
+// InstitutionRatingViewItem is one historical rating distribution snapshot.
+type InstitutionRatingViewItem struct {
+	Date  json.Number `json:"date"` // int64 or quoted string timestamp
+	Buy   int32       `json:"buy"`
+	Over  int32       `json:"over"`
+	Hold  int32       `json:"hold"`
+	Under int32       `json:"under"`
+	Sell  int32       `json:"sell"`
+	Total int32       `json:"total"`
+}
+
+// ── industry_rank ─────────────────────────────────────────────────
+
+// IndustryRankResponse is the raw response for GET /v1/quote/industry/rank.
+type IndustryRankResponse struct {
+	Items []IndustryRankGroup `json:"items"`
+}
+
+// IndustryRankGroup is a group of ranked industry items.
+type IndustryRankGroup struct {
+	Lists []IndustryRankItem `json:"lists"`
+}
+
+// IndustryRankItem is one ranked industry item.
+type IndustryRankItem struct {
+	Name          string `json:"name"`
+	CounterID     string `json:"counter_id"`
+	Chg           string `json:"chg"`
+	LeadingName   string `json:"leading_name"`
+	LeadingTicker string `json:"leading_ticker"`
+	LeadingChg    string `json:"leading_chg"`
+	ValueName     string `json:"value_name"`
+	ValueData     string `json:"value_data"`
+}
+
+// ── industry_peers ────────────────────────────────────────────────
+
+// IndustryPeersResponse is the raw response for
+// GET /v1/quote/industries/peers.
+type IndustryPeersResponse struct {
+	Top   IndustryPeersTop  `json:"top"`
+	Chain *IndustryPeerNode `json:"chain"`
+}
+
+// IndustryPeersTop holds the top-level industry info.
+type IndustryPeersTop struct {
+	Name   string `json:"name"`
+	Market string `json:"market"`
+}
+
+// IndustryPeerNode is a node in the recursive industry peer chain.
+type IndustryPeerNode struct {
+	Name     string             `json:"name"`
+	CounterID string            `json:"counter_id"`
+	StockNum string             `json:"stock_num"`
+	Chg      string             `json:"chg"`
+	YtdChg   string             `json:"ytd_chg"`
+	Next     []IndustryPeerNode `json:"next"`
+}
+
+// ── financial_report_snapshot ─────────────────────────────────────
+
+// FinancialReportSnapshot is the raw response for
+// GET /v1/quote/financials/earnings-snapshot.
+type FinancialReportSnapshot struct {
+	Name              string                    `json:"name"`
+	Ticker            string                    `json:"ticker"`
+	FpStart           string                    `json:"fp_start"`
+	FpEnd             string                    `json:"fp_end"`
+	Currency          string                    `json:"currency"`
+	ReportDesc        string                    `json:"report_desc"`
+	FoRevenue         *SnapshotForecastMetric   `json:"fo_revenue"`
+	FoEbit            *SnapshotForecastMetric   `json:"fo_ebit"`
+	FoEps             *SnapshotForecastMetric   `json:"fo_eps"`
+	FrRevenue         *SnapshotReportedMetric   `json:"fr_revenue"`
+	FrProfit          *SnapshotReportedMetric   `json:"fr_profit"`
+	FrOperateCash     *SnapshotReportedMetric   `json:"fr_operate_cash"`
+	FrInvestCash      *SnapshotReportedMetric   `json:"fr_invest_cash"`
+	FrFinanceCash     *SnapshotReportedMetric   `json:"fr_finance_cash"`
+	FrTotalAssets     *SnapshotReportedMetric   `json:"fr_total_assets"`
+	FrTotalLiability  *SnapshotReportedMetric   `json:"fr_total_liability"`
+	FrRoeTtm          string                    `json:"fr_roe_ttm"`
+	FrProfitMargin    string                    `json:"fr_profit_margin"`
+	FrProfitMarginTtm string                    `json:"fr_profit_margin_ttm"`
+	FrAssetTurnTtm    string                    `json:"fr_asset_turn_ttm"`
+	FrLeverageTtm     string                    `json:"fr_leverage_ttm"`
+	FrDebtAssetsRatio string                    `json:"fr_debt_assets_ratio"`
+}
+
+// SnapshotForecastMetric is a forecast metric in the financial report snapshot.
+type SnapshotForecastMetric struct {
+	Value    string `json:"value"`
+	Yoy      string `json:"yoy"`
+	CmpDesc  string `json:"cmp_desc"`
+	EstValue string `json:"est_value"`
+}
+
+// SnapshotReportedMetric is a reported metric in the financial report snapshot.
+type SnapshotReportedMetric struct {
+	Value string `json:"value"`
+	Yoy   string `json:"yoy"`
+}

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -638,12 +638,12 @@ type InstitutionRatingViews struct {
 // InstitutionRatingViewItem is one historical rating distribution snapshot.
 type InstitutionRatingViewItem struct {
 	Date  json.Number `json:"date"` // int64 or quoted string timestamp
-	Buy   int32       `json:"buy"`
-	Over  int32       `json:"over"`
-	Hold  int32       `json:"hold"`
-	Under int32       `json:"under"`
-	Sell  int32       `json:"sell"`
-	Total int32       `json:"total"`
+	Buy   string      `json:"buy"`
+	Over  string      `json:"over"`
+	Hold  string      `json:"hold"`
+	Under string      `json:"under"`
+	Sell  string      `json:"sell"`
+	Total string      `json:"total"`
 }
 
 // ── industry_rank ─────────────────────────────────────────────────
@@ -687,12 +687,12 @@ type IndustryPeersTop struct {
 
 // IndustryPeerNode is a node in the recursive industry peer chain.
 type IndustryPeerNode struct {
-	Name     string             `json:"name"`
-	CounterID string            `json:"counter_id"`
-	StockNum string             `json:"stock_num"`
-	Chg      string             `json:"chg"`
-	YtdChg   string             `json:"ytd_chg"`
-	Next     []IndustryPeerNode `json:"next"`
+	Name      string             `json:"name"`
+	CounterID string             `json:"counter_id"`
+	StockNum  int32              `json:"stock_num"`
+	Chg       string             `json:"chg"`
+	YtdChg    string             `json:"ytd_chg"`
+	Next      []IndustryPeerNode `json:"next"`
 }
 
 // ── financial_report_snapshot ─────────────────────────────────────

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -977,3 +977,257 @@ type RatingLeafIndicator struct {
 	// Letter grade.
 	Letter string
 }
+
+// ── industry_rank enums ───────────────────────────────────────────
+
+// IndustryRankIndicator identifies the metric used for industry ranking.
+type IndustryRankIndicator string
+
+const (
+	// IndustryRankIndicator0 is indicator 0.
+	IndustryRankIndicator0 IndustryRankIndicator = "0"
+	// IndustryRankIndicator1 is indicator 1.
+	IndustryRankIndicator1 IndustryRankIndicator = "1"
+	// IndustryRankIndicator2 is indicator 2.
+	IndustryRankIndicator2 IndustryRankIndicator = "2"
+	// IndustryRankIndicator3 is indicator 3.
+	IndustryRankIndicator3 IndustryRankIndicator = "3"
+	// IndustryRankIndicator4 is indicator 4.
+	IndustryRankIndicator4 IndustryRankIndicator = "4"
+	// IndustryRankIndicator5 is indicator 5.
+	IndustryRankIndicator5 IndustryRankIndicator = "5"
+	// IndustryRankIndicator6 is indicator 6.
+	IndustryRankIndicator6 IndustryRankIndicator = "6"
+	// IndustryRankIndicator7 is indicator 7.
+	IndustryRankIndicator7 IndustryRankIndicator = "7"
+)
+
+// IndustryRankSortType specifies the sort direction for industry ranking.
+type IndustryRankSortType string
+
+const (
+	// IndustryRankSortTypeAscending sorts ascending.
+	IndustryRankSortTypeAscending IndustryRankSortType = "0"
+	// IndustryRankSortTypeDescending sorts descending.
+	IndustryRankSortTypeDescending IndustryRankSortType = "1"
+)
+
+// ── business_segments ─────────────────────────────────────────────
+
+// BusinessSegments is the response for FundamentalContext.BusinessSegments.
+type BusinessSegments struct {
+	// Report date.
+	Date string
+	// Total revenue.
+	Total string
+	// Reporting currency.
+	Currency string
+	// Business segment breakdown.
+	Business []BusinessSegmentItem
+}
+
+// BusinessSegmentItem is one business segment entry (latest snapshot).
+type BusinessSegmentItem struct {
+	// Segment name.
+	Name string
+	// Percentage of total revenue.
+	Percent string
+}
+
+// BusinessSegmentsHistory is the response for
+// FundamentalContext.BusinessSegmentsHistory.
+type BusinessSegmentsHistory struct {
+	// Historical snapshots.
+	Historical []BusinessSegmentsHistoricalItem
+}
+
+// BusinessSegmentsHistoricalItem is one historical business segments snapshot.
+type BusinessSegmentsHistoricalItem struct {
+	// Report date.
+	Date string
+	// Total revenue.
+	Total string
+	// Reporting currency.
+	Currency string
+	// Business segment breakdown.
+	Business []BusinessSegmentHistoryItem
+	// Regional breakdown.
+	Regionals []BusinessSegmentHistoryItem
+}
+
+// BusinessSegmentHistoryItem is one business/regional segment entry in a
+// historical snapshot.
+type BusinessSegmentHistoryItem struct {
+	// Segment name.
+	Name string
+	// Percentage of total.
+	Percent string
+	// Absolute value.
+	Value string
+}
+
+// ── institution_rating_views ──────────────────────────────────────
+
+// InstitutionRatingViews is the response for
+// FundamentalContext.InstitutionRatingViews.
+type InstitutionRatingViews struct {
+	// Historical rating distribution snapshots.
+	Elist []InstitutionRatingViewItem
+}
+
+// InstitutionRatingViewItem is one historical rating distribution snapshot.
+type InstitutionRatingViewItem struct {
+	// Date of the snapshot.
+	Date time.Time
+	// Number of "Buy" ratings.
+	Buy int32
+	// Number of "Outperform" ratings.
+	Over int32
+	// Number of "Hold" ratings.
+	Hold int32
+	// Number of "Underperform" ratings.
+	Under int32
+	// Number of "Sell" ratings.
+	Sell int32
+	// Total analyst count.
+	Total int32
+}
+
+// ── industry_rank ─────────────────────────────────────────────────
+
+// IndustryRankResponse is the response for FundamentalContext.IndustryRank.
+type IndustryRankResponse struct {
+	// Grouped rank items.
+	Items []IndustryRankGroup
+}
+
+// IndustryRankGroup is a group of ranked industry items.
+type IndustryRankGroup struct {
+	// Items in this group.
+	Lists []IndustryRankItem
+}
+
+// IndustryRankItem is one ranked industry item.
+type IndustryRankItem struct {
+	// Industry / sector name.
+	Name string
+	// Counter ID of the industry.
+	CounterID string
+	// Change percentage.
+	Chg string
+	// Name of the leading stock.
+	LeadingName string
+	// Ticker of the leading stock.
+	LeadingTicker string
+	// Change percentage of the leading stock.
+	LeadingChg string
+	// Value label name.
+	ValueName string
+	// Value data.
+	ValueData string
+}
+
+// ── industry_peers ────────────────────────────────────────────────
+
+// IndustryPeersResponse is the response for FundamentalContext.IndustryPeers.
+type IndustryPeersResponse struct {
+	// Top-level industry node info.
+	Top IndustryPeersTop
+	// Root peer chain node (nil if no data).
+	Chain *IndustryPeerNode
+}
+
+// IndustryPeersTop holds the top-level industry info.
+type IndustryPeersTop struct {
+	// Industry name.
+	Name string
+	// Market code.
+	Market string
+}
+
+// IndustryPeerNode is a node in the recursive industry peer chain.
+type IndustryPeerNode struct {
+	// Node name.
+	Name string
+	// Counter ID.
+	CounterID string
+	// Number of stocks in this node.
+	StockNum string
+	// Change percentage.
+	Chg string
+	// Year-to-date change.
+	YtdChg string
+	// Child nodes (recursive).
+	Next []IndustryPeerNode
+}
+
+// ── financial_report_snapshot ─────────────────────────────────────
+
+// FinancialReportSnapshot is the response for
+// FundamentalContext.FinancialReportSnapshot.
+type FinancialReportSnapshot struct {
+	// Company name.
+	Name string
+	// Ticker code.
+	Ticker string
+	// Fiscal period start date.
+	FpStart string
+	// Fiscal period end date.
+	FpEnd string
+	// Reporting currency.
+	Currency string
+	// Report description.
+	ReportDesc string
+	// Forecast revenue.
+	FoRevenue *SnapshotForecastMetric
+	// Forecast EBIT.
+	FoEbit *SnapshotForecastMetric
+	// Forecast EPS.
+	FoEps *SnapshotForecastMetric
+	// Reported revenue.
+	FrRevenue *SnapshotReportedMetric
+	// Reported net profit.
+	FrProfit *SnapshotReportedMetric
+	// Reported operating cash flow.
+	FrOperateCash *SnapshotReportedMetric
+	// Reported investing cash flow.
+	FrInvestCash *SnapshotReportedMetric
+	// Reported financing cash flow.
+	FrFinanceCash *SnapshotReportedMetric
+	// Reported total assets.
+	FrTotalAssets *SnapshotReportedMetric
+	// Reported total liabilities.
+	FrTotalLiability *SnapshotReportedMetric
+	// ROE TTM.
+	FrRoeTtm string
+	// Profit margin.
+	FrProfitMargin string
+	// Profit margin TTM.
+	FrProfitMarginTtm string
+	// Asset turnover TTM.
+	FrAssetTurnTtm string
+	// Leverage TTM.
+	FrLeverageTtm string
+	// Debt-to-assets ratio.
+	FrDebtAssetsRatio string
+}
+
+// SnapshotForecastMetric is a forecast metric in the financial report snapshot.
+type SnapshotForecastMetric struct {
+	// Actual value.
+	Value string
+	// Year-over-year change.
+	Yoy string
+	// Beat/miss description.
+	CmpDesc string
+	// Consensus estimate value.
+	EstValue string
+}
+
+// SnapshotReportedMetric is a reported metric in the financial report snapshot.
+type SnapshotReportedMetric struct {
+	// Actual value.
+	Value string
+	// Year-over-year change.
+	Yoy string
+}

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1080,17 +1080,17 @@ type InstitutionRatingViewItem struct {
 	// Date of the snapshot.
 	Date time.Time
 	// Number of "Buy" ratings.
-	Buy int32
+	Buy string
 	// Number of "Outperform" ratings.
-	Over int32
+	Over string
 	// Number of "Hold" ratings.
-	Hold int32
+	Hold string
 	// Number of "Underperform" ratings.
-	Under int32
+	Under string
 	// Number of "Sell" ratings.
-	Sell int32
+	Sell string
 	// Total analyst count.
-	Total int32
+	Total string
 }
 
 // ── industry_rank ─────────────────────────────────────────────────
@@ -1152,7 +1152,7 @@ type IndustryPeerNode struct {
 	// Counter ID.
 	CounterID string
 	// Number of stocks in this node.
-	StockNum string
+	StockNum int32
 	// Change percentage.
 	Chg string
 	// Year-to-date change.


### PR DESCRIPTION
## Summary

Ports 5 new fundamental data APIs from [longbridge-terminal PR #202](https://github.com/longbridge/longbridge-terminal/pull/202) into the Go SDK.

- **`BusinessSegments`** — current-period revenue segment breakdown (`GET /v1/quote/fundamentals/business-segments`)
- **`BusinessSegmentsHistory`** — historical segment trends by period/category (`GET /v1/quote/fundamentals/business-segments/history`)
- **`InstitutionRatingViews`** — monthly buy/hold/sell distribution timeline (`GET /v1/quote/ratings/institutional`)
- **`IndustryRank`** — industry ranking list by market and indicator (`GET /v1/quote/industry/rank`)
- **`IndustryPeers`** — hierarchical sub-sector tree for a BK counter_id (`GET /v1/quote/industries/peers`)
- **`FinancialReportSnapshot`** — AI earnings summary + forecast vs actual beat/miss analysis (`GET /v1/quote/financials/earnings-snapshot`)

## Changes

- `fundamental/jsontypes/types.go` — raw JSON wire-format structs
- `fundamental/types.go` — Go-idiomatic public types + `IndustryRankIndicator` / `IndustryRankSortType` constants
- `fundamental/context.go` — 6 new methods on `*FundamentalContext` with inline converters
- `CHANGELOG.md` — updated `[Unreleased]` section

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./fundamental/...` — passes
- [ ] Verify each endpoint against the terminal CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)