### PR TITLE
feat(fundamental): add MacrodataIndicators and Macrodata methods

### DIFF
--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1611,3 +1611,110 @@ func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *Finan
 		FrDebtAssetsRatio: j.FrDebtAssetsRatio,
 	}
 }
+
+// ─── EconomicIndicator ────────────────────────────────────────────────────
+
+// EconomicIndicatorList fetches the list of available macroeconomic indicators.
+//
+// Pass offset and limit as nil to use the API defaults (offset=0, limit=100).
+// To fetch all ~619 indicators in one call pass limit=1000.
+//
+// Path: GET /v1/quote/macrodata
+func (c *FundamentalContext) EconomicIndicatorList(
+	ctx context.Context,
+	offset *int32,
+	limit *int32,
+) ([]EconomicIndicatorInfo, error) {
+	q := url.Values{}
+	if offset != nil {
+		q.Set("offset", fmt.Sprintf("%d", *offset))
+	}
+	if limit != nil {
+		q.Set("limit", fmt.Sprintf("%d", *limit))
+	}
+	var resp jsontypes.EconomicIndicatorListResponse
+	if err := c.httpClient.Get(ctx, "/v1/quote/macrodata", q, &resp); err != nil {
+		return nil, err
+	}
+	out := make([]EconomicIndicatorInfo, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		out = append(out, convertEconomicIndicatorInfo(&item))
+	}
+	return out, nil
+}
+
+// EconomicIndicator fetches historical data for a specific macroeconomic
+// indicator.
+//
+// startTime and endTime are Unix timestamps in seconds; pass nil to omit.
+// limit defaults to 100 (max 100) when nil.
+//
+// Path: GET /v1/quote/macrodata/{indicator_code}
+func (c *FundamentalContext) EconomicIndicator(
+	ctx context.Context,
+	indicatorCode string,
+	startTime *int64,
+	endTime *int64,
+	limit *int32,
+) (*EconomicIndicatorResponse, error) {
+	q := url.Values{}
+	if startTime != nil {
+		q.Set("start_time", fmt.Sprintf("%d", *startTime))
+	}
+	if endTime != nil {
+		q.Set("end_time", fmt.Sprintf("%d", *endTime))
+	}
+	if limit != nil {
+		q.Set("limit", fmt.Sprintf("%d", *limit))
+	}
+	var resp jsontypes.EconomicIndicatorResponse
+	path := "/v1/quote/macrodata/" + indicatorCode
+	if err := c.httpClient.Get(ctx, path, q, &resp); err != nil {
+		return nil, err
+	}
+	data := make([]EconomicIndicatorData, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		data = append(data, convertEconomicIndicatorData(&d))
+	}
+	return &EconomicIndicatorResponse{
+		Info: convertEconomicIndicatorInfo(&resp.Info),
+		Data: data,
+	}, nil
+}
+
+func convertMultiLanguageText(j jsontypes.MultiLanguageText) MultiLanguageText {
+	return MultiLanguageText{
+		English:            j.English,
+		SimplifiedChinese:  j.SimplifiedChinese,
+		TraditionalChinese: j.TraditionalChinese,
+	}
+}
+
+func convertEconomicIndicatorInfo(j *jsontypes.EconomicIndicatorInfo) EconomicIndicatorInfo {
+	return EconomicIndicatorInfo{
+		IndicatorCode:    j.IndicatorCode,
+		SourceOrg:        j.SourceOrg,
+		Country:          j.Country,
+		Name:             convertMultiLanguageText(j.Name),
+		AdjustmentFactor: j.AdjustmentFactor,
+		Periodicity:      j.Periodicity,
+		Category:         j.Category,
+		Describe:         convertMultiLanguageText(j.Describe),
+		Importance:       j.Importance,
+		StartDate:        j.StartDate,
+	}
+}
+
+func convertEconomicIndicatorData(j *jsontypes.EconomicIndicatorData) EconomicIndicatorData {
+	return EconomicIndicatorData{
+		Period:        j.Period,
+		ReleaseAt:     j.ReleaseAt,
+		ActualValue:   j.ActualValue,
+		PreviousValue: j.PreviousValue,
+		ForecastValue: j.ForecastValue,
+		RevisedValue:  j.RevisedValue,
+		NextReleaseAt: j.NextReleaseAt,
+		Unit:          convertMultiLanguageText(j.Unit),
+		UnitPrefix:    convertMultiLanguageText(j.UnitPrefix),
+	}
+}

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1624,7 +1624,7 @@ func (c *FundamentalContext) MacrodataIndicators(
 	ctx context.Context,
 	offset *int32,
 	limit *int32,
-) ([]EconomicIndicatorInfo, error) {
+) ([]MacrodataIndicatorInfo, error) {
 	q := url.Values{}
 	if offset != nil {
 		q.Set("offset", fmt.Sprintf("%d", *offset))
@@ -1636,9 +1636,9 @@ func (c *FundamentalContext) MacrodataIndicators(
 	if err := c.httpClient.Get(ctx, "/v1/quote/macrodata", q, &resp); err != nil {
 		return nil, err
 	}
-	out := make([]EconomicIndicatorInfo, 0, len(resp.Data))
+	out := make([]MacrodataIndicatorInfo, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		out = append(out, convertEconomicIndicatorInfo(&item))
+		out = append(out, convertMacrodataIndicatorInfo(&item))
 	}
 	return out, nil
 }
@@ -1662,7 +1662,7 @@ func (c *FundamentalContext) Macrodata(
 	startDate *string,
 	endDate *string,
 	limit *int32,
-) (*EconomicIndicatorResponse, error) {
+) (*MacrodataResponse, error) {
 	q := url.Values{}
 	if startDate != nil {
 		q.Set("start_time", *startDate+"T00:00:00Z")
@@ -1673,17 +1673,17 @@ func (c *FundamentalContext) Macrodata(
 	if limit != nil {
 		q.Set("limit", fmt.Sprintf("%d", *limit))
 	}
-	var resp jsontypes.EconomicIndicatorResponse
+	var resp jsontypes.MacrodataResponse
 	path := "/v1/quote/macrodata/" + indicatorCode
 	if err := c.httpClient.Get(ctx, path, q, &resp); err != nil {
 		return nil, err
 	}
-	data := make([]EconomicIndicatorData, 0, len(resp.Data))
+	data := make([]MacrodataRecord, 0, len(resp.Data))
 	for _, d := range resp.Data {
-		data = append(data, convertEconomicIndicatorData(&d))
+		data = append(data, convertMacrodataRecord(&d))
 	}
-	return &EconomicIndicatorResponse{
-		Info: convertEconomicIndicatorInfo(&resp.Info),
+	return &MacrodataResponse{
+		Info: convertMacrodataIndicatorInfo(&resp.Info),
 		Data: data,
 	}, nil
 }
@@ -1705,8 +1705,8 @@ func parseOptionalTimestamp(n json.Number) *time.Time {
 	return &t
 }
 
-func convertEconomicIndicatorInfo(j *jsontypes.EconomicIndicatorInfo) EconomicIndicatorInfo {
-	return EconomicIndicatorInfo{
+func convertMacrodataIndicatorInfo(j *jsontypes.MacrodataIndicatorInfo) MacrodataIndicatorInfo {
+	return MacrodataIndicatorInfo{
 		IndicatorCode:    j.IndicatorCode,
 		SourceOrg:        j.SourceOrg,
 		Country:          j.Country,
@@ -1720,8 +1720,8 @@ func convertEconomicIndicatorInfo(j *jsontypes.EconomicIndicatorInfo) EconomicIn
 	}
 }
 
-func convertEconomicIndicatorData(j *jsontypes.EconomicIndicatorData) EconomicIndicatorData {
-	return EconomicIndicatorData{
+func convertMacrodataRecord(j *jsontypes.MacrodataRecord) MacrodataRecord {
+	return MacrodataRecord{
 		Period:        j.Period,
 		ReleaseAt:     parseOptionalTimestamp(j.ReleaseAt),
 		ActualValue:   j.ActualValue,

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1624,7 +1624,7 @@ func (c *FundamentalContext) MacrodataIndicators(
 	ctx context.Context,
 	offset *int32,
 	limit *int32,
-) ([]MacrodataIndicatorInfo, error) {
+) ([]MacrodataIndicator, error) {
 	q := url.Values{}
 	if offset != nil {
 		q.Set("offset", fmt.Sprintf("%d", *offset))
@@ -1636,9 +1636,9 @@ func (c *FundamentalContext) MacrodataIndicators(
 	if err := c.httpClient.Get(ctx, "/v1/quote/macrodata", q, &resp); err != nil {
 		return nil, err
 	}
-	out := make([]MacrodataIndicatorInfo, 0, len(resp.Data))
+	out := make([]MacrodataIndicator, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		out = append(out, convertMacrodataIndicatorInfo(&item))
+		out = append(out, convertMacrodataIndicator(&item))
 	}
 	return out, nil
 }
@@ -1678,12 +1678,12 @@ func (c *FundamentalContext) Macrodata(
 	if err := c.httpClient.Get(ctx, path, q, &resp); err != nil {
 		return nil, err
 	}
-	data := make([]MacrodataRecord, 0, len(resp.Data))
+	data := make([]Macrodata, 0, len(resp.Data))
 	for _, d := range resp.Data {
-		data = append(data, convertMacrodataRecord(&d))
+		data = append(data, convertMacrodata(&d))
 	}
 	return &MacrodataResponse{
-		Info: convertMacrodataIndicatorInfo(&resp.Info),
+		Info: convertMacrodataIndicator(&resp.Info),
 		Data: data,
 	}, nil
 }
@@ -1705,8 +1705,8 @@ func parseOptionalTimestamp(n json.Number) *time.Time {
 	return &t
 }
 
-func convertMacrodataIndicatorInfo(j *jsontypes.MacrodataIndicatorInfo) MacrodataIndicatorInfo {
-	return MacrodataIndicatorInfo{
+func convertMacrodataIndicator(j *jsontypes.MacrodataIndicator) MacrodataIndicator {
+	return MacrodataIndicator{
 		IndicatorCode:    j.IndicatorCode,
 		SourceOrg:        j.SourceOrg,
 		Country:          j.Country,
@@ -1720,8 +1720,8 @@ func convertMacrodataIndicatorInfo(j *jsontypes.MacrodataIndicatorInfo) Macrodat
 	}
 }
 
-func convertMacrodataRecord(j *jsontypes.MacrodataRecord) MacrodataRecord {
-	return MacrodataRecord{
+func convertMacrodata(j *jsontypes.Macrodata) Macrodata {
+	return Macrodata{
 		Period:        j.Period,
 		ReleaseAt:     parseOptionalTimestamp(j.ReleaseAt),
 		ActualValue:   j.ActualValue,

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1612,15 +1612,15 @@ func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *Finan
 	}
 }
 
-// ─── EconomicIndicator ────────────────────────────────────────────────────
+// ─── Macrodata ────────────────────────────────────────────────────
 
-// EconomicIndicatorList fetches the list of available macroeconomic indicators.
+// MacrodataList fetches the list of available macroeconomic indicators.
 //
 // Pass offset and limit as nil to use the API defaults (offset=0, limit=100).
 // To fetch all ~619 indicators in one call pass limit=1000.
 //
 // Path: GET /v1/quote/macrodata
-func (c *FundamentalContext) EconomicIndicatorList(
+func (c *FundamentalContext) MacrodataList(
 	ctx context.Context,
 	offset *int32,
 	limit *int32,
@@ -1643,14 +1643,14 @@ func (c *FundamentalContext) EconomicIndicatorList(
 	return out, nil
 }
 
-// EconomicIndicator fetches historical data for a specific macroeconomic
+// Macrodata fetches historical data for a specific macroeconomic
 // indicator.
 //
 // startTime and endTime are Unix timestamps in seconds; pass nil to omit.
 // limit defaults to 100 (max 100) when nil.
 //
 // Path: GET /v1/quote/macrodata/{indicator_code}
-func (c *FundamentalContext) EconomicIndicator(
+func (c *FundamentalContext) Macrodata(
 	ctx context.Context,
 	indicatorCode string,
 	startTime *int64,

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1690,6 +1690,15 @@ func convertMultiLanguageText(j jsontypes.MultiLanguageText) MultiLanguageText {
 	}
 }
 
+func parseOptionalTimestamp(n json.Number) *time.Time {
+	v := parseTimestampNumber(n)
+	if v == 0 {
+		return nil
+	}
+	t := time.Unix(v, 0).UTC()
+	return &t
+}
+
 func convertEconomicIndicatorInfo(j *jsontypes.EconomicIndicatorInfo) EconomicIndicatorInfo {
 	return EconomicIndicatorInfo{
 		IndicatorCode:    j.IndicatorCode,
@@ -1701,19 +1710,19 @@ func convertEconomicIndicatorInfo(j *jsontypes.EconomicIndicatorInfo) EconomicIn
 		Category:         j.Category,
 		Describe:         convertMultiLanguageText(j.Describe),
 		Importance:       j.Importance,
-		StartDate:        j.StartDate,
+		StartDate:        parseOptionalTimestamp(j.StartDate),
 	}
 }
 
 func convertEconomicIndicatorData(j *jsontypes.EconomicIndicatorData) EconomicIndicatorData {
 	return EconomicIndicatorData{
 		Period:        j.Period,
-		ReleaseAt:     j.ReleaseAt,
+		ReleaseAt:     parseOptionalTimestamp(j.ReleaseAt),
 		ActualValue:   j.ActualValue,
 		PreviousValue: j.PreviousValue,
 		ForecastValue: j.ForecastValue,
 		RevisedValue:  j.RevisedValue,
-		NextReleaseAt: j.NextReleaseAt,
+		NextReleaseAt: parseOptionalTimestamp(j.NextReleaseAt),
 		Unit:          convertMultiLanguageText(j.Unit),
 		UnitPrefix:    convertMultiLanguageText(j.UnitPrefix),
 	}

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1653,16 +1653,16 @@ func (c *FundamentalContext) MacrodataIndicators(
 func (c *FundamentalContext) Macrodata(
 	ctx context.Context,
 	indicatorCode string,
-	startTime *int64,
-	endTime *int64,
+	startTime *time.Time,
+	endTime *time.Time,
 	limit *int32,
 ) (*EconomicIndicatorResponse, error) {
 	q := url.Values{}
 	if startTime != nil {
-		q.Set("start_time", fmt.Sprintf("%d", *startTime))
+		q.Set("start_time", startTime.UTC().Format(time.RFC3339))
 	}
 	if endTime != nil {
-		q.Set("end_time", fmt.Sprintf("%d", *endTime))
+		q.Set("end_time", endTime.UTC().Format(time.RFC3339))
 	}
 	if limit != nil {
 		q.Set("limit", fmt.Sprintf("%d", *limit))

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1650,19 +1650,25 @@ func (c *FundamentalContext) MacrodataIndicators(
 // limit defaults to 100 (max 100) when nil.
 //
 // Path: GET /v1/quote/macrodata/{indicator_code}
+// Macrodata fetches historical data for a specific macroeconomic indicator.
+//
+// startDate and endDate are date strings in "YYYY-MM-DD" format.
+// startDate is sent as YYYY-MM-DDT00:00:00Z; endDate is sent as YYYY-MM-DDT23:59:59Z.
+//
+// Path: GET /v1/quote/macrodata/{indicator_code}
 func (c *FundamentalContext) Macrodata(
 	ctx context.Context,
 	indicatorCode string,
-	startTime *time.Time,
-	endTime *time.Time,
+	startDate *string,
+	endDate *string,
 	limit *int32,
 ) (*EconomicIndicatorResponse, error) {
 	q := url.Values{}
-	if startTime != nil {
-		q.Set("start_time", startTime.UTC().Format(time.RFC3339))
+	if startDate != nil {
+		q.Set("start_time", *startDate+"T00:00:00Z")
 	}
-	if endTime != nil {
-		q.Set("end_time", endTime.UTC().Format(time.RFC3339))
+	if endDate != nil {
+		q.Set("end_time", *endDate+"T23:59:59Z")
 	}
 	if limit != nil {
 		q.Set("limit", fmt.Sprintf("%d", *limit))

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1696,12 +1696,15 @@ func convertMultiLanguageText(j jsontypes.MultiLanguageText) MultiLanguageText {
 	}
 }
 
-func parseOptionalTimestamp(n json.Number) *time.Time {
-	v := parseTimestampNumber(n)
-	if v == 0 {
+func parseOptionalRFC3339(s string) *time.Time {
+	if s == "" {
 		return nil
 	}
-	t := time.Unix(v, 0).UTC()
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	t = t.UTC()
 	return &t
 }
 
@@ -1716,19 +1719,19 @@ func convertMacrodataIndicator(j *jsontypes.MacrodataIndicator) MacrodataIndicat
 		Category:         j.Category,
 		Describe:         convertMultiLanguageText(j.Describe),
 		Importance:       j.Importance,
-		StartDate:        parseOptionalTimestamp(j.StartDate),
+		StartDate:        parseOptionalRFC3339(j.StartDate),
 	}
 }
 
 func convertMacrodata(j *jsontypes.Macrodata) Macrodata {
 	return Macrodata{
 		Period:        j.Period,
-		ReleaseAt:     parseOptionalTimestamp(j.ReleaseAt),
+		ReleaseAt:     parseOptionalRFC3339(j.ReleaseAt),
 		ActualValue:   j.ActualValue,
 		PreviousValue: j.PreviousValue,
 		ForecastValue: j.ForecastValue,
 		RevisedValue:  j.RevisedValue,
-		NextReleaseAt: parseOptionalTimestamp(j.NextReleaseAt),
+		NextReleaseAt: parseOptionalRFC3339(j.NextReleaseAt),
 		Unit:          convertMultiLanguageText(j.Unit),
 		UnitPrefix:    convertMultiLanguageText(j.UnitPrefix),
 	}

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1614,13 +1614,13 @@ func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *Finan
 
 // ─── Macrodata ────────────────────────────────────────────────────
 
-// MacrodataList fetches the list of available macroeconomic indicators.
+// MacrodataIndicators fetches the list of available macroeconomic indicators.
 //
 // Pass offset and limit as nil to use the API defaults (offset=0, limit=100).
 // To fetch all ~619 indicators in one call pass limit=1000.
 //
 // Path: GET /v1/quote/macrodata
-func (c *FundamentalContext) MacrodataList(
+func (c *FundamentalContext) MacrodataIndicators(
 	ctx context.Context,
 	offset *int32,
 	limit *int32,

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -806,8 +806,8 @@ type MultiLanguageText struct {
 	TraditionalChinese  string `json:"traditional_chinese"`
 }
 
-// EconomicIndicatorInfo is the metadata for one macroeconomic indicator.
-type EconomicIndicatorInfo struct {
+// MacrodataIndicatorInfo is the metadata for one macroeconomic indicator.
+type MacrodataIndicatorInfo struct {
 	IndicatorCode    string            `json:"indicator_code"`
 	SourceOrg        string            `json:"source_org"`
 	Country          string            `json:"country"`
@@ -822,12 +822,12 @@ type EconomicIndicatorInfo struct {
 
 // EconomicIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
 type EconomicIndicatorListResponse struct {
-	Data []EconomicIndicatorInfo `json:"data"`
+	Data []MacrodataIndicatorInfo `json:"data"`
 }
 
-// EconomicIndicatorData is one historical data point for a macroeconomic
+// MacrodataRecord is one historical data point for a macroeconomic
 // indicator.
-type EconomicIndicatorData struct {
+type MacrodataRecord struct {
 	Period        string            `json:"period"`
 	ReleaseAt     json.Number       `json:"release_at"`
 	ActualValue   string            `json:"actual_value"`
@@ -839,9 +839,9 @@ type EconomicIndicatorData struct {
 	UnitPrefix    MultiLanguageText `json:"unit_prefix"`
 }
 
-// EconomicIndicatorResponse is the raw response for
+// MacrodataResponse is the raw response for
 // GET /v1/quote/macrodata/{indicator_code}.
-type EconomicIndicatorResponse struct {
-	Info EconomicIndicatorInfo   `json:"info"`
-	Data []EconomicIndicatorData `json:"data"`
+type MacrodataResponse struct {
+	Info MacrodataIndicatorInfo   `json:"info"`
+	Data []MacrodataRecord `json:"data"`
 }

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -806,8 +806,8 @@ type MultiLanguageText struct {
 	TraditionalChinese  string `json:"traditional_chinese"`
 }
 
-// MacrodataIndicatorInfo is the metadata for one macroeconomic indicator.
-type MacrodataIndicatorInfo struct {
+// MacrodataIndicator is the metadata for one macroeconomic indicator.
+type MacrodataIndicator struct {
 	IndicatorCode    string            `json:"indicator_code"`
 	SourceOrg        string            `json:"source_org"`
 	Country          string            `json:"country"`
@@ -822,12 +822,12 @@ type MacrodataIndicatorInfo struct {
 
 // EconomicIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
 type EconomicIndicatorListResponse struct {
-	Data []MacrodataIndicatorInfo `json:"data"`
+	Data []MacrodataIndicator `json:"data"`
 }
 
-// MacrodataRecord is one historical data point for a macroeconomic
+// Macrodata is one historical data point for a macroeconomic
 // indicator.
-type MacrodataRecord struct {
+type Macrodata struct {
 	Period        string            `json:"period"`
 	ReleaseAt     json.Number       `json:"release_at"`
 	ActualValue   string            `json:"actual_value"`
@@ -842,6 +842,6 @@ type MacrodataRecord struct {
 // MacrodataResponse is the raw response for
 // GET /v1/quote/macrodata/{indicator_code}.
 type MacrodataResponse struct {
-	Info MacrodataIndicatorInfo   `json:"info"`
-	Data []MacrodataRecord `json:"data"`
+	Info MacrodataIndicator   `json:"info"`
+	Data []Macrodata `json:"data"`
 }

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -817,24 +817,24 @@ type MacrodataIndicator struct {
 	Category         string            `json:"category"`
 	Describe         MultiLanguageText `json:"describe"`
 	Importance       int32             `json:"importance"`
-	StartDate        json.Number       `json:"start_date"`
+	StartDate        string            `json:"start_date"`
 }
 
 // EconomicIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
 type EconomicIndicatorListResponse struct {
-	Data []MacrodataIndicator `json:"data"`
+	Data []MacrodataIndicator `json:"list"`
 }
 
 // Macrodata is one historical data point for a macroeconomic
 // indicator.
 type Macrodata struct {
 	Period        string            `json:"period"`
-	ReleaseAt     json.Number       `json:"release_at"`
+	ReleaseAt     string            `json:"release_at"`
 	ActualValue   string            `json:"actual_value"`
 	PreviousValue string            `json:"previous_value"`
 	ForecastValue string            `json:"forecast_value"`
 	RevisedValue  string            `json:"revised_value"`
-	NextReleaseAt json.Number       `json:"next_release_at"`
+	NextReleaseAt string            `json:"next_release_at"`
 	Unit          MultiLanguageText `json:"unit"`
 	UnitPrefix    MultiLanguageText `json:"unit_prefix"`
 }

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -795,3 +795,53 @@ type HoldingDetail struct {
 	HoldingType     string `json:"holding_type"`
 	HoldingTypeName string `json:"holding_type_name"`
 }
+
+// ── economic_indicator ────────────────────────────────────────────────────
+
+// MultiLanguageText is localized text in simplified Chinese, traditional
+// Chinese, and English.
+type MultiLanguageText struct {
+	English             string `json:"english"`
+	SimplifiedChinese   string `json:"simplified_chinese"`
+	TraditionalChinese  string `json:"traditional_chinese"`
+}
+
+// EconomicIndicatorInfo is the metadata for one macroeconomic indicator.
+type EconomicIndicatorInfo struct {
+	IndicatorCode    string            `json:"indicator_code"`
+	SourceOrg        string            `json:"source_org"`
+	Country          string            `json:"country"`
+	Name             MultiLanguageText `json:"name"`
+	AdjustmentFactor string            `json:"adjustment_factor"`
+	Periodicity      string            `json:"periodicity"`
+	Category         string            `json:"category"`
+	Describe         MultiLanguageText `json:"describe"`
+	Importance       int32             `json:"importance"`
+	StartDate        string            `json:"start_date"`
+}
+
+// EconomicIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
+type EconomicIndicatorListResponse struct {
+	Data []EconomicIndicatorInfo `json:"data"`
+}
+
+// EconomicIndicatorData is one historical data point for a macroeconomic
+// indicator.
+type EconomicIndicatorData struct {
+	Period         string            `json:"period"`
+	ReleaseAt      string            `json:"release_at"`
+	ActualValue    string            `json:"actual_value"`
+	PreviousValue  string            `json:"previous_value"`
+	ForecastValue  string            `json:"forecast_value"`
+	RevisedValue   string            `json:"revised_value"`
+	NextReleaseAt  string            `json:"next_release_at"`
+	Unit           MultiLanguageText `json:"unit"`
+	UnitPrefix     MultiLanguageText `json:"unit_prefix"`
+}
+
+// EconomicIndicatorResponse is the raw response for
+// GET /v1/quote/macrodata/{indicator_code}.
+type EconomicIndicatorResponse struct {
+	Info EconomicIndicatorInfo   `json:"info"`
+	Data []EconomicIndicatorData `json:"data"`
+}

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -817,7 +817,7 @@ type EconomicIndicatorInfo struct {
 	Category         string            `json:"category"`
 	Describe         MultiLanguageText `json:"describe"`
 	Importance       int32             `json:"importance"`
-	StartDate        string            `json:"start_date"`
+	StartDate        json.Number       `json:"start_date"`
 }
 
 // EconomicIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
@@ -828,15 +828,15 @@ type EconomicIndicatorListResponse struct {
 // EconomicIndicatorData is one historical data point for a macroeconomic
 // indicator.
 type EconomicIndicatorData struct {
-	Period         string            `json:"period"`
-	ReleaseAt      string            `json:"release_at"`
-	ActualValue    string            `json:"actual_value"`
-	PreviousValue  string            `json:"previous_value"`
-	ForecastValue  string            `json:"forecast_value"`
-	RevisedValue   string            `json:"revised_value"`
-	NextReleaseAt  string            `json:"next_release_at"`
-	Unit           MultiLanguageText `json:"unit"`
-	UnitPrefix     MultiLanguageText `json:"unit_prefix"`
+	Period        string            `json:"period"`
+	ReleaseAt     json.Number       `json:"release_at"`
+	ActualValue   string            `json:"actual_value"`
+	PreviousValue string            `json:"previous_value"`
+	ForecastValue string            `json:"forecast_value"`
+	RevisedValue  string            `json:"revised_value"`
+	NextReleaseAt json.Number       `json:"next_release_at"`
+	Unit          MultiLanguageText `json:"unit"`
+	UnitPrefix    MultiLanguageText `json:"unit_prefix"`
 }
 
 // EconomicIndicatorResponse is the raw response for

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1352,3 +1352,52 @@ type AssetAllocationResponse struct {
 	// Info are the asset allocation groups.
 	Info []*AssetAllocationGroup
 }
+
+// ── economic_indicator ────────────────────────────────────────────────────
+
+// MultiLanguageText is localized text in simplified Chinese, traditional
+// Chinese, and English.
+type MultiLanguageText struct {
+	English            string
+	SimplifiedChinese  string
+	TraditionalChinese string
+}
+
+// EconomicIndicatorInfo is the metadata for one macroeconomic indicator.
+type EconomicIndicatorInfo struct {
+	// IndicatorCode is the external vendor code (input to EconomicIndicator).
+	IndicatorCode    string
+	SourceOrg        string
+	Country          string
+	Name             MultiLanguageText
+	AdjustmentFactor string
+	// Periodicity is the release periodicity (e.g. monthly / quarterly).
+	Periodicity string
+	Category    string
+	Describe    MultiLanguageText
+	// Importance — higher is more important.
+	Importance int32
+	// StartDate is the start date of data coverage (unix timestamp string).
+	StartDate string
+}
+
+// EconomicIndicatorData is one historical data point for a macroeconomic
+// indicator.
+type EconomicIndicatorData struct {
+	// Period is the statistical period (e.g. "2024-Q1", "2024-03").
+	Period        string
+	ReleaseAt     string
+	ActualValue   string
+	PreviousValue string
+	ForecastValue string
+	RevisedValue  string
+	NextReleaseAt string
+	Unit          MultiLanguageText
+	UnitPrefix    MultiLanguageText
+}
+
+// EconomicIndicatorResponse is the response for FundamentalContext.EconomicIndicator.
+type EconomicIndicatorResponse struct {
+	Info EconomicIndicatorInfo
+	Data []EconomicIndicatorData
+}

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1363,8 +1363,8 @@ type MultiLanguageText struct {
 	TraditionalChinese string
 }
 
-// MacrodataIndicatorInfo is the metadata for one macroeconomic indicator.
-type MacrodataIndicatorInfo struct {
+// MacrodataIndicator is the metadata for one macroeconomic indicator.
+type MacrodataIndicator struct {
 	// IndicatorCode is the external vendor code (input to EconomicIndicator).
 	IndicatorCode    string
 	SourceOrg        string
@@ -1381,9 +1381,9 @@ type MacrodataIndicatorInfo struct {
 	StartDate *time.Time
 }
 
-// MacrodataRecord is one historical data point for a macroeconomic
+// Macrodata is one historical data point for a macroeconomic
 // indicator.
-type MacrodataRecord struct {
+type Macrodata struct {
 	// Period is the statistical period (e.g. "2024-Q1", "2024-03").
 	Period        string
 	ReleaseAt     *time.Time
@@ -1398,6 +1398,6 @@ type MacrodataRecord struct {
 
 // MacrodataResponse is the response for FundamentalContext.EconomicIndicator.
 type MacrodataResponse struct {
-	Info MacrodataIndicatorInfo
-	Data []MacrodataRecord
+	Info MacrodataIndicator
+	Data []Macrodata
 }

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1377,8 +1377,8 @@ type EconomicIndicatorInfo struct {
 	Describe    MultiLanguageText
 	// Importance — higher is more important.
 	Importance int32
-	// StartDate is the start date of data coverage (unix timestamp string).
-	StartDate string
+	// StartDate is the start date of data coverage; nil if unset.
+	StartDate *time.Time
 }
 
 // EconomicIndicatorData is one historical data point for a macroeconomic
@@ -1386,12 +1386,12 @@ type EconomicIndicatorInfo struct {
 type EconomicIndicatorData struct {
 	// Period is the statistical period (e.g. "2024-Q1", "2024-03").
 	Period        string
-	ReleaseAt     string
+	ReleaseAt     *time.Time
 	ActualValue   string
 	PreviousValue string
 	ForecastValue string
 	RevisedValue  string
-	NextReleaseAt string
+	NextReleaseAt *time.Time
 	Unit          MultiLanguageText
 	UnitPrefix    MultiLanguageText
 }

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1363,8 +1363,8 @@ type MultiLanguageText struct {
 	TraditionalChinese string
 }
 
-// EconomicIndicatorInfo is the metadata for one macroeconomic indicator.
-type EconomicIndicatorInfo struct {
+// MacrodataIndicatorInfo is the metadata for one macroeconomic indicator.
+type MacrodataIndicatorInfo struct {
 	// IndicatorCode is the external vendor code (input to EconomicIndicator).
 	IndicatorCode    string
 	SourceOrg        string
@@ -1381,9 +1381,9 @@ type EconomicIndicatorInfo struct {
 	StartDate *time.Time
 }
 
-// EconomicIndicatorData is one historical data point for a macroeconomic
+// MacrodataRecord is one historical data point for a macroeconomic
 // indicator.
-type EconomicIndicatorData struct {
+type MacrodataRecord struct {
 	// Period is the statistical period (e.g. "2024-Q1", "2024-03").
 	Period        string
 	ReleaseAt     *time.Time
@@ -1396,8 +1396,8 @@ type EconomicIndicatorData struct {
 	UnitPrefix    MultiLanguageText
 }
 
-// EconomicIndicatorResponse is the response for FundamentalContext.EconomicIndicator.
-type EconomicIndicatorResponse struct {
-	Info EconomicIndicatorInfo
-	Data []EconomicIndicatorData
+// MacrodataResponse is the response for FundamentalContext.EconomicIndicator.
+type MacrodataResponse struct {
+	Info MacrodataIndicatorInfo
+	Data []MacrodataRecord
 }


### PR DESCRIPTION
## Summary

Two new methods on `FundamentalContext`:

- `MacrodataIndicators(ctx, offset, limit)` — `GET /v1/quote/macrodata` — list all macroeconomic indicators (~619 total)
- `Macrodata(ctx, indicatorCode, startDate, endDate, limit)` — `GET /v1/quote/macrodata/{indicator_code}` — fetch historical data for one indicator

`startDate` / `endDate` accept `"YYYY-MM-DD"` strings and are sent to the API as `YYYY-MM-DDT00:00:00Z` / `YYYY-MM-DDT23:59:59Z`.

## New Types

| Type | Description |
|------|-------------|
| `MultiLanguageText` | Localized text (English / Simplified Chinese / Traditional Chinese) |
| `MacrodataIndicator` | Indicator metadata (code, country, category, periodicity, importance, etc.) |
| `Macrodata` | One historical data point (period, actual/previous/forecast/revised values, release timestamps, unit) |
| `MacrodataResponse` | `Info MacrodataIndicator` + `Data []Macrodata` |

## Time field formats

All timestamp fields (`StartDate`, `ReleaseAt`, `NextReleaseAt`) are returned as `*time.Time` (UTC) — consistent with other SDK methods.

## Related

- Upstream (all language SDKs): longbridge/openapi#540