### PR TITLE
feat(fundamental): add MacroeconomicIndicators and Macroeconomic methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 - `QuoteContext.SymbolToCounterIds` — batch convert symbols to counter IDs via `POST /v1/quote/symbol-to-counter-ids`
 - `QuoteContext.ResolveCounterIds` — local-first counter ID resolution with batched remote fallback and automatic caching
 - `FundamentalContext.EtfAssetAllocation` — ETF asset allocation (holdings / regional / asset class / industry) via `GET /v1/quote/etf-asset-allocation`
-- `FundamentalContext.MacrodataIndicators` — list macroeconomic indicators via `GET /v1/quote/macrodata`
-- `FundamentalContext.Macrodata` — historical data for a specific indicator via `GET /v1/quote/macrodata/{indicator_code}`; `startDate` / `endDate` accept `"YYYY-MM-DD"` strings
-- New types: `MultiLanguageText`, `MacrodataIndicator`, `Macrodata`, `MacrodataResponse`
+- `FundamentalContext.MacroeconomicIndicators(country, offset, limit)` — list macroeconomic indicators via `GET /v1/quote/macrodata`; filter by `MacroeconomicCountry` (HK/CN/US/EU/JP/SG); response includes `Count`
+- `FundamentalContext.Macroeconomic(indicatorCode, startDate, endDate, offset, limit)` — historical data for a specific indicator via `GET /v1/quote/macrodata/{indicator_code}`; `startDate` / `endDate` accept `"YYYY-MM-DD"` strings; response includes `Count`
+- New types: `MultiLanguageText`, `MacroeconomicCountry`, `MacroeconomicImportance`, `MacroeconomicIndicator`, `MacroeconomicIndicatorListResponse`, `Macroeconomic`, `MacroeconomicResponse`
 
 ## [v0.24.2] - 2026-06-02
 

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1681,7 +1681,7 @@ func (c *FundamentalContext) Macroeconomic(
 	}
 	data := make([]Macroeconomic, 0, len(resp.Data))
 	for _, d := range resp.Data {
-		data = append(data, convertMacrodata(&d))
+		data = append(data, convertMacroeconomic(&d))
 	}
 	return &MacroeconomicResponse{
 		Info:  convertMacroeconomicIndicator(&resp.Info),
@@ -1725,7 +1725,7 @@ func convertMacroeconomicIndicator(j *jsontypes.MacroeconomicIndicator) Macroeco
 	}
 }
 
-func convertMacrodata(j *jsontypes.Macroeconomic) Macroeconomic {
+func convertMacroeconomic(j *jsontypes.Macroeconomic) Macroeconomic {
 	return Macroeconomic{
 		Period:        j.Period,
 		ReleaseAt:     parseOptionalRFC3339(j.ReleaseAt),

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1628,7 +1628,7 @@ func (c *FundamentalContext) MacroeconomicIndicators(
 ) (*MacroeconomicIndicatorListResponse, error) {
 	q := url.Values{}
 	if country != nil {
-		q.Set("country", macrodataCountryToAPIValue(*country))
+		q.Set("country", macroeconomicCountryToAPIValue(*country))
 	}
 	if offset != nil {
 		q.Set("offset", fmt.Sprintf("%d", *offset))
@@ -1739,7 +1739,7 @@ func convertMacrodata(j *jsontypes.Macroeconomic) Macroeconomic {
 	}
 }
 
-func macrodataCountryToAPIValue(c MacroeconomicCountry) string {
+func macroeconomicCountryToAPIValue(c MacroeconomicCountry) string {
 	switch c {
 	case MacroeconomicCountryHK:
 		return "Hong Kong SAR China"

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1612,7 +1612,7 @@ func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *Finan
 	}
 }
 
-// ─── Macrodata ────────────────────────────────────────────────────
+// ─── Macroeconomic ────────────────────────────────────────────────────
 
 // MacroeconomicIndicators fetches the list of available macroeconomic indicators.
 //
@@ -1647,13 +1647,13 @@ func (c *FundamentalContext) MacroeconomicIndicators(
 	return &MacroeconomicIndicatorListResponse{Data: out, Count: resp.Count}, nil
 }
 
-// Macrodata fetches historical data for a specific macroeconomic indicator.
+// Macroeconomic fetches historical data for a specific macroeconomic indicator.
 //
 // startDate and endDate are date strings in "YYYY-MM-DD" format.
 // startDate is sent as YYYY-MM-DDT00:00:00Z; endDate is sent as YYYY-MM-DDT23:59:59Z.
 //
 // Path: GET /v1/quote/macrodata/{indicator_code}
-func (c *FundamentalContext) Macrodata(
+func (c *FundamentalContext) Macroeconomic(
 	ctx context.Context,
 	indicatorCode string,
 	startDate *string,
@@ -1679,7 +1679,7 @@ func (c *FundamentalContext) Macrodata(
 	if err := c.httpClient.Get(ctx, path, q, &resp); err != nil {
 		return nil, err
 	}
-	data := make([]Macrodata, 0, len(resp.Data))
+	data := make([]Macroeconomic, 0, len(resp.Data))
 	for _, d := range resp.Data {
 		data = append(data, convertMacrodata(&d))
 	}
@@ -1725,8 +1725,8 @@ func convertMacroeconomicIndicator(j *jsontypes.MacroeconomicIndicator) Macroeco
 	}
 }
 
-func convertMacrodata(j *jsontypes.Macrodata) Macrodata {
-	return Macrodata{
+func convertMacrodata(j *jsontypes.Macroeconomic) Macroeconomic {
+	return Macroeconomic{
 		Period:        j.Period,
 		ReleaseAt:     parseOptionalRFC3339(j.ReleaseAt),
 		ActualValue:   j.ActualValue,

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1616,16 +1616,20 @@ func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *Finan
 
 // MacrodataIndicators fetches the list of available macroeconomic indicators.
 //
-// Pass offset and limit as nil to use the API defaults (offset=0, limit=100).
-// To fetch all ~619 indicators in one call pass limit=1000.
+// Pass country to filter by country code (e.g. MacrodataCountryUS).
+// Pass nil for all countries.
 //
 // Path: GET /v1/quote/macrodata
 func (c *FundamentalContext) MacrodataIndicators(
 	ctx context.Context,
+	country *MacrodataCountry,
 	offset *int32,
 	limit *int32,
-) ([]MacrodataIndicator, error) {
+) (*MacrodataIndicatorListResponse, error) {
 	q := url.Values{}
+	if country != nil {
+		q.Set("country", string(*country))
+	}
 	if offset != nil {
 		q.Set("offset", fmt.Sprintf("%d", *offset))
 	}
@@ -1640,16 +1644,9 @@ func (c *FundamentalContext) MacrodataIndicators(
 	for _, item := range resp.Data {
 		out = append(out, convertMacrodataIndicator(&item))
 	}
-	return out, nil
+	return &MacrodataIndicatorListResponse{Data: out, Count: resp.Count}, nil
 }
 
-// Macrodata fetches historical data for a specific macroeconomic
-// indicator.
-//
-// startTime and endTime are Unix timestamps in seconds; pass nil to omit.
-// limit defaults to 100 (max 100) when nil.
-//
-// Path: GET /v1/quote/macrodata/{indicator_code}
 // Macrodata fetches historical data for a specific macroeconomic indicator.
 //
 // startDate and endDate are date strings in "YYYY-MM-DD" format.
@@ -1661,6 +1658,7 @@ func (c *FundamentalContext) Macrodata(
 	indicatorCode string,
 	startDate *string,
 	endDate *string,
+	offset *int32,
 	limit *int32,
 ) (*MacrodataResponse, error) {
 	q := url.Values{}
@@ -1669,6 +1667,9 @@ func (c *FundamentalContext) Macrodata(
 	}
 	if endDate != nil {
 		q.Set("end_time", *endDate+"T23:59:59Z")
+	}
+	if offset != nil {
+		q.Set("offset", fmt.Sprintf("%d", *offset))
 	}
 	if limit != nil {
 		q.Set("limit", fmt.Sprintf("%d", *limit))
@@ -1683,8 +1684,9 @@ func (c *FundamentalContext) Macrodata(
 		data = append(data, convertMacrodata(&d))
 	}
 	return &MacrodataResponse{
-		Info: convertMacrodataIndicator(&resp.Info),
-		Data: data,
+		Info:  convertMacrodataIndicator(&resp.Info),
+		Data:  data,
+		Count: resp.Count,
 	}, nil
 }
 

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1628,7 +1628,7 @@ func (c *FundamentalContext) MacrodataIndicators(
 ) (*MacrodataIndicatorListResponse, error) {
 	q := url.Values{}
 	if country != nil {
-		q.Set("country", string(*country))
+		q.Set("country", macrodataCountryToAPIValue(*country))
 	}
 	if offset != nil {
 		q.Set("offset", fmt.Sprintf("%d", *offset))
@@ -1736,5 +1736,24 @@ func convertMacrodata(j *jsontypes.Macrodata) Macrodata {
 		NextReleaseAt: parseOptionalRFC3339(j.NextReleaseAt),
 		Unit:          convertMultiLanguageText(j.Unit),
 		UnitPrefix:    convertMultiLanguageText(j.UnitPrefix),
+	}
+}
+
+func macrodataCountryToAPIValue(c MacrodataCountry) string {
+	switch c {
+	case MacrodataCountryHK:
+		return "Hong Kong SAR China"
+	case MacrodataCountryCN:
+		return "China (Mainland)"
+	case MacrodataCountryUS:
+		return "United States"
+	case MacrodataCountryEU:
+		return "Euro Zone"
+	case MacrodataCountryJP:
+		return "Japan"
+	case MacrodataCountrySG:
+		return "Singapore"
+	default:
+		return string(c)
 	}
 }

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1614,18 +1614,18 @@ func convertFinancialReportSnapshot(j *jsontypes.FinancialReportSnapshot) *Finan
 
 // ─── Macrodata ────────────────────────────────────────────────────
 
-// MacrodataIndicators fetches the list of available macroeconomic indicators.
+// MacroeconomicIndicators fetches the list of available macroeconomic indicators.
 //
-// Pass country to filter by country code (e.g. MacrodataCountryUS).
+// Pass country to filter by country code (e.g. MacroeconomicCountryUS).
 // Pass nil for all countries.
 //
 // Path: GET /v1/quote/macrodata
-func (c *FundamentalContext) MacrodataIndicators(
+func (c *FundamentalContext) MacroeconomicIndicators(
 	ctx context.Context,
-	country *MacrodataCountry,
+	country *MacroeconomicCountry,
 	offset *int32,
 	limit *int32,
-) (*MacrodataIndicatorListResponse, error) {
+) (*MacroeconomicIndicatorListResponse, error) {
 	q := url.Values{}
 	if country != nil {
 		q.Set("country", macrodataCountryToAPIValue(*country))
@@ -1636,15 +1636,15 @@ func (c *FundamentalContext) MacrodataIndicators(
 	if limit != nil {
 		q.Set("limit", fmt.Sprintf("%d", *limit))
 	}
-	var resp jsontypes.MacrodataIndicatorListResponse
+	var resp jsontypes.MacroeconomicIndicatorListResponse
 	if err := c.httpClient.Get(ctx, "/v1/quote/macrodata", q, &resp); err != nil {
 		return nil, err
 	}
-	out := make([]MacrodataIndicator, 0, len(resp.Data))
+	out := make([]MacroeconomicIndicator, 0, len(resp.Data))
 	for _, item := range resp.Data {
-		out = append(out, convertMacrodataIndicator(&item))
+		out = append(out, convertMacroeconomicIndicator(&item))
 	}
-	return &MacrodataIndicatorListResponse{Data: out, Count: resp.Count}, nil
+	return &MacroeconomicIndicatorListResponse{Data: out, Count: resp.Count}, nil
 }
 
 // Macrodata fetches historical data for a specific macroeconomic indicator.
@@ -1660,7 +1660,7 @@ func (c *FundamentalContext) Macrodata(
 	endDate *string,
 	offset *int32,
 	limit *int32,
-) (*MacrodataResponse, error) {
+) (*MacroeconomicResponse, error) {
 	q := url.Values{}
 	if startDate != nil {
 		q.Set("start_time", *startDate+"T00:00:00Z")
@@ -1674,7 +1674,7 @@ func (c *FundamentalContext) Macrodata(
 	if limit != nil {
 		q.Set("limit", fmt.Sprintf("%d", *limit))
 	}
-	var resp jsontypes.MacrodataResponse
+	var resp jsontypes.MacroeconomicResponse
 	path := "/v1/quote/macrodata/" + indicatorCode
 	if err := c.httpClient.Get(ctx, path, q, &resp); err != nil {
 		return nil, err
@@ -1683,8 +1683,8 @@ func (c *FundamentalContext) Macrodata(
 	for _, d := range resp.Data {
 		data = append(data, convertMacrodata(&d))
 	}
-	return &MacrodataResponse{
-		Info:  convertMacrodataIndicator(&resp.Info),
+	return &MacroeconomicResponse{
+		Info:  convertMacroeconomicIndicator(&resp.Info),
 		Data:  data,
 		Count: resp.Count,
 	}, nil
@@ -1710,8 +1710,8 @@ func parseOptionalRFC3339(s string) *time.Time {
 	return &t
 }
 
-func convertMacrodataIndicator(j *jsontypes.MacrodataIndicator) MacrodataIndicator {
-	return MacrodataIndicator{
+func convertMacroeconomicIndicator(j *jsontypes.MacroeconomicIndicator) MacroeconomicIndicator {
+	return MacroeconomicIndicator{
 		IndicatorCode:    j.IndicatorCode,
 		SourceOrg:        j.SourceOrg,
 		Country:          j.Country,
@@ -1739,19 +1739,19 @@ func convertMacrodata(j *jsontypes.Macrodata) Macrodata {
 	}
 }
 
-func macrodataCountryToAPIValue(c MacrodataCountry) string {
+func macrodataCountryToAPIValue(c MacroeconomicCountry) string {
 	switch c {
-	case MacrodataCountryHK:
+	case MacroeconomicCountryHK:
 		return "Hong Kong SAR China"
-	case MacrodataCountryCN:
+	case MacroeconomicCountryCN:
 		return "China (Mainland)"
-	case MacrodataCountryUS:
+	case MacroeconomicCountryUS:
 		return "United States"
-	case MacrodataCountryEU:
+	case MacroeconomicCountryEU:
 		return "Euro Zone"
-	case MacrodataCountryJP:
+	case MacroeconomicCountryJP:
 		return "Japan"
-	case MacrodataCountrySG:
+	case MacroeconomicCountrySG:
 		return "Singapore"
 	default:
 		return string(c)

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -826,9 +826,9 @@ type MacroeconomicIndicatorListResponse struct {
 	Count int32                `json:"count"`
 }
 
-// Macrodata is one historical data point for a macroeconomic
+// Macroeconomic is one historical data point for a macroeconomic
 // indicator.
-type Macrodata struct {
+type Macroeconomic struct {
 	Period        string            `json:"period"`
 	ReleaseAt     string            `json:"release_at"`
 	ActualValue   string            `json:"actual_value"`
@@ -844,6 +844,6 @@ type Macrodata struct {
 // GET /v1/quote/macrodata/{indicator_code}.
 type MacroeconomicResponse struct {
 	Info  MacroeconomicIndicator `json:"info"`
-	Data  []Macrodata        `json:"data"`
+	Data  []Macroeconomic        `json:"data"`
 	Count int32              `json:"count"`
 }

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -822,7 +822,8 @@ type MacrodataIndicator struct {
 
 // MacrodataIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
 type MacrodataIndicatorListResponse struct {
-	Data []MacrodataIndicator `json:"list"`
+	Data  []MacrodataIndicator `json:"list"`
+	Count int32                `json:"count"`
 }
 
 // Macrodata is one historical data point for a macroeconomic
@@ -842,6 +843,7 @@ type Macrodata struct {
 // MacrodataResponse is the raw response for
 // GET /v1/quote/macrodata/{indicator_code}.
 type MacrodataResponse struct {
-	Info MacrodataIndicator   `json:"info"`
-	Data []Macrodata `json:"data"`
+	Info  MacrodataIndicator `json:"info"`
+	Data  []Macrodata        `json:"data"`
+	Count int32              `json:"count"`
 }

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -806,8 +806,8 @@ type MultiLanguageText struct {
 	TraditionalChinese  string `json:"traditional_chinese"`
 }
 
-// MacrodataIndicator is the metadata for one macroeconomic indicator.
-type MacrodataIndicator struct {
+// MacroeconomicIndicator is the metadata for one macroeconomic indicator.
+type MacroeconomicIndicator struct {
 	IndicatorCode    string            `json:"indicator_code"`
 	SourceOrg        string            `json:"source_org"`
 	Country          string            `json:"country"`
@@ -820,9 +820,9 @@ type MacrodataIndicator struct {
 	StartDate        string            `json:"start_date"`
 }
 
-// MacrodataIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
-type MacrodataIndicatorListResponse struct {
-	Data  []MacrodataIndicator `json:"list"`
+// MacroeconomicIndicatorListResponse is the raw response for GET /v1/quote/macrodata.
+type MacroeconomicIndicatorListResponse struct {
+	Data  []MacroeconomicIndicator `json:"list"`
 	Count int32                `json:"count"`
 }
 
@@ -840,10 +840,10 @@ type Macrodata struct {
 	UnitPrefix    MultiLanguageText `json:"unit_prefix"`
 }
 
-// MacrodataResponse is the raw response for
+// MacroeconomicResponse is the raw response for
 // GET /v1/quote/macrodata/{indicator_code}.
-type MacrodataResponse struct {
-	Info  MacrodataIndicator `json:"info"`
+type MacroeconomicResponse struct {
+	Info  MacroeconomicIndicator `json:"info"`
 	Data  []Macrodata        `json:"data"`
 	Count int32              `json:"count"`
 }

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1367,19 +1367,11 @@ type MultiLanguageText struct {
 type MacrodataCountry string
 
 const (
+	MacrodataCountryHK MacrodataCountry = "HK" // Hong Kong SAR China
+	MacrodataCountryCN MacrodataCountry = "CN" // China (Mainland)
 	MacrodataCountryUS MacrodataCountry = "US" // United States
-	MacrodataCountryCN MacrodataCountry = "CN" // China
 	MacrodataCountryEU MacrodataCountry = "EU" // Euro Zone
 	MacrodataCountryJP MacrodataCountry = "JP" // Japan
-	MacrodataCountryUK MacrodataCountry = "UK" // United Kingdom
-	MacrodataCountryDE MacrodataCountry = "DE" // Germany
-	MacrodataCountryFR MacrodataCountry = "FR" // France
-	MacrodataCountryAU MacrodataCountry = "AU" // Australia
-	MacrodataCountryCA MacrodataCountry = "CA" // Canada
-	MacrodataCountryKR MacrodataCountry = "KR" // South Korea
-	MacrodataCountryIN MacrodataCountry = "IN" // India
-	MacrodataCountryBR MacrodataCountry = "BR" // Brazil
-	MacrodataCountryHK MacrodataCountry = "HK" // Hong Kong
 	MacrodataCountrySG MacrodataCountry = "SG" // Singapore
 )
 

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1363,37 +1363,37 @@ type MultiLanguageText struct {
 	TraditionalChinese string
 }
 
-// MacrodataCountry is a country code for filtering macroeconomic indicators.
-type MacrodataCountry string
+// MacroeconomicCountry is a country code for filtering macroeconomic indicators.
+type MacroeconomicCountry string
 
 const (
-	MacrodataCountryHK MacrodataCountry = "HK" // Hong Kong SAR China
-	MacrodataCountryCN MacrodataCountry = "CN" // China (Mainland)
-	MacrodataCountryUS MacrodataCountry = "US" // United States
-	MacrodataCountryEU MacrodataCountry = "EU" // Euro Zone
-	MacrodataCountryJP MacrodataCountry = "JP" // Japan
-	MacrodataCountrySG MacrodataCountry = "SG" // Singapore
+	MacroeconomicCountryHK MacroeconomicCountry = "HK" // Hong Kong SAR China
+	MacroeconomicCountryCN MacroeconomicCountry = "CN" // China (Mainland)
+	MacroeconomicCountryUS MacroeconomicCountry = "US" // United States
+	MacroeconomicCountryEU MacroeconomicCountry = "EU" // Euro Zone
+	MacroeconomicCountryJP MacroeconomicCountry = "JP" // Japan
+	MacroeconomicCountrySG MacroeconomicCountry = "SG" // Singapore
 )
 
-// MacrodataImportance is the importance level of a macroeconomic indicator.
-type MacrodataImportance int32
+// MacroeconomicImportance is the importance level of a macroeconomic indicator.
+type MacroeconomicImportance int32
 
 const (
-	MacrodataImportanceLow    MacrodataImportance = 1
-	MacrodataImportanceMedium MacrodataImportance = 2
-	MacrodataImportanceHigh   MacrodataImportance = 3
+	MacroeconomicImportanceLow    MacroeconomicImportance = 1
+	MacroeconomicImportanceMedium MacroeconomicImportance = 2
+	MacroeconomicImportanceHigh   MacroeconomicImportance = 3
 )
 
-// MacrodataIndicatorListResponse is the response for FundamentalContext.MacrodataIndicators.
-type MacrodataIndicatorListResponse struct {
+// MacroeconomicIndicatorListResponse is the response for FundamentalContext.MacroeconomicIndicators.
+type MacroeconomicIndicatorListResponse struct {
 	// Data is the list of indicators.
-	Data []MacrodataIndicator
+	Data []MacroeconomicIndicator
 	// Count is the total number of indicators matching the query.
 	Count int32
 }
 
-// MacrodataIndicator is the metadata for one macroeconomic indicator.
-type MacrodataIndicator struct {
+// MacroeconomicIndicator is the metadata for one macroeconomic indicator.
+type MacroeconomicIndicator struct {
 	// IndicatorCode is the external vendor code (input to Macrodata).
 	IndicatorCode    string
 	SourceOrg        string
@@ -1424,9 +1424,9 @@ type Macrodata struct {
 	UnitPrefix    MultiLanguageText
 }
 
-// MacrodataResponse is the response for FundamentalContext.Macrodata.
-type MacrodataResponse struct {
-	Info  MacrodataIndicator
+// MacroeconomicResponse is the response for FundamentalContext.Macrodata.
+type MacroeconomicResponse struct {
+	Info  MacroeconomicIndicator
 	Data  []Macrodata
 	// Count is the total number of historical data points.
 	Count int32

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1363,9 +1363,46 @@ type MultiLanguageText struct {
 	TraditionalChinese string
 }
 
+// MacrodataCountry is a country code for filtering macroeconomic indicators.
+type MacrodataCountry string
+
+const (
+	MacrodataCountryUS MacrodataCountry = "US" // United States
+	MacrodataCountryCN MacrodataCountry = "CN" // China
+	MacrodataCountryEU MacrodataCountry = "EU" // Euro Zone
+	MacrodataCountryJP MacrodataCountry = "JP" // Japan
+	MacrodataCountryUK MacrodataCountry = "UK" // United Kingdom
+	MacrodataCountryDE MacrodataCountry = "DE" // Germany
+	MacrodataCountryFR MacrodataCountry = "FR" // France
+	MacrodataCountryAU MacrodataCountry = "AU" // Australia
+	MacrodataCountryCA MacrodataCountry = "CA" // Canada
+	MacrodataCountryKR MacrodataCountry = "KR" // South Korea
+	MacrodataCountryIN MacrodataCountry = "IN" // India
+	MacrodataCountryBR MacrodataCountry = "BR" // Brazil
+	MacrodataCountryHK MacrodataCountry = "HK" // Hong Kong
+	MacrodataCountrySG MacrodataCountry = "SG" // Singapore
+)
+
+// MacrodataImportance is the importance level of a macroeconomic indicator.
+type MacrodataImportance int32
+
+const (
+	MacrodataImportanceLow    MacrodataImportance = 1
+	MacrodataImportanceMedium MacrodataImportance = 2
+	MacrodataImportanceHigh   MacrodataImportance = 3
+)
+
+// MacrodataIndicatorListResponse is the response for FundamentalContext.MacrodataIndicators.
+type MacrodataIndicatorListResponse struct {
+	// Data is the list of indicators.
+	Data []MacrodataIndicator
+	// Count is the total number of indicators matching the query.
+	Count int32
+}
+
 // MacrodataIndicator is the metadata for one macroeconomic indicator.
 type MacrodataIndicator struct {
-	// IndicatorCode is the external vendor code (input to EconomicIndicator).
+	// IndicatorCode is the external vendor code (input to Macrodata).
 	IndicatorCode    string
 	SourceOrg        string
 	Country          string
@@ -1375,14 +1412,13 @@ type MacrodataIndicator struct {
 	Periodicity string
 	Category    string
 	Describe    MultiLanguageText
-	// Importance — higher is more important.
+	// Importance: 1=Low, 2=Medium, 3=High.
 	Importance int32
 	// StartDate is the start date of data coverage; nil if unset.
 	StartDate *time.Time
 }
 
-// Macrodata is one historical data point for a macroeconomic
-// indicator.
+// Macrodata is one historical data point for a macroeconomic indicator.
 type Macrodata struct {
 	// Period is the statistical period (e.g. "2024-Q1", "2024-03").
 	Period        string
@@ -1396,8 +1432,10 @@ type Macrodata struct {
 	UnitPrefix    MultiLanguageText
 }
 
-// MacrodataResponse is the response for FundamentalContext.EconomicIndicator.
+// MacrodataResponse is the response for FundamentalContext.Macrodata.
 type MacrodataResponse struct {
-	Info MacrodataIndicator
-	Data []Macrodata
+	Info  MacrodataIndicator
+	Data  []Macrodata
+	// Count is the total number of historical data points.
+	Count int32
 }

--- a/fundamental/types.go
+++ b/fundamental/types.go
@@ -1394,7 +1394,7 @@ type MacroeconomicIndicatorListResponse struct {
 
 // MacroeconomicIndicator is the metadata for one macroeconomic indicator.
 type MacroeconomicIndicator struct {
-	// IndicatorCode is the external vendor code (input to Macrodata).
+	// IndicatorCode is the external vendor code (input to Macroeconomic).
 	IndicatorCode    string
 	SourceOrg        string
 	Country          string
@@ -1410,8 +1410,8 @@ type MacroeconomicIndicator struct {
 	StartDate *time.Time
 }
 
-// Macrodata is one historical data point for a macroeconomic indicator.
-type Macrodata struct {
+// Macroeconomic is one historical data point for a macroeconomic indicator.
+type Macroeconomic struct {
 	// Period is the statistical period (e.g. "2024-Q1", "2024-03").
 	Period        string
 	ReleaseAt     *time.Time
@@ -1424,10 +1424,10 @@ type Macrodata struct {
 	UnitPrefix    MultiLanguageText
 }
 
-// MacroeconomicResponse is the response for FundamentalContext.Macrodata.
+// MacroeconomicResponse is the response for FundamentalContext.Macroeconomic.
 type MacroeconomicResponse struct {
 	Info  MacroeconomicIndicator
-	Data  []Macrodata
+	Data  []Macroeconomic
 	// Count is the total number of historical data points.
 	Count int32
 }


### PR DESCRIPTION
## Summary

Two new methods on `FundamentalContext`:

- `MacroeconomicIndicators(ctx, country, offset, limit)` — `GET /v1/quote/macrodata` — list macroeconomic indicators; filter by country (`MacroeconomicCountryHK/CN/US/EU/JP/SG`); response includes `Count` (total matching)
- `Macroeconomic(ctx, indicatorCode, startDate, endDate, offset, limit)` — `GET /v1/quote/macrodata/{indicator_code}` — historical data for a specific indicator; `startDate` / `endDate` accept `"YYYY-MM-DD"` strings; response includes `Count` (total data points)

## New Types

| Type | Description |
|------|-------------|
| `MultiLanguageText` | Localized text (English / Simplified Chinese / Traditional Chinese) |
| `MacroeconomicCountry` | Country filter (`MacroeconomicCountryHK/CN/US/EU/JP/SG`); converts to full name for API |
| `MacroeconomicImportance` | `MacroeconomicImportanceLow=1` / `Medium=2` / `High=3` |
| `MacroeconomicIndicator` | Indicator metadata |
| `MacroeconomicIndicatorListResponse` | `Data []MacroeconomicIndicator` + `Count int32` |
| `Macroeconomic` | One historical data point |
| `MacroeconomicResponse` | `Info MacroeconomicIndicator` + `Data []Macroeconomic` + `Count int32` |

## Related

- Upstream (all language SDKs): longbridge/openapi#540