### PR TITLE
fix(macroeconomic): add frequence and importance to detail info

### DIFF
--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -1733,6 +1733,8 @@ func convertV2MacroeconomicDetail(j *jsontypes.V2MacroeconomicDetail) Macroecono
 		Country:       j.Market,
 		Name:          j.IndicatorName,
 		Describe:      j.Description,
+		Periodicity:   j.Frequence,
+		Importance:    j.Importance,
 	}
 }
 

--- a/fundamental/jsontypes/types.go
+++ b/fundamental/jsontypes/types.go
@@ -883,6 +883,9 @@ type V2MacroeconomicDetail struct {
 	Unit          string                  `json:"unit"`
 	Description   string                  `json:"description"`
 	Market        string                  `json:"market"`
+	// Frequence: day/week/month/quarter/half_year/year
+	Frequence     string                  `json:"frequence"`
+	Importance    int32                   `json:"importance"`
 	IndicatorData []V2IndicatorDataDetail `json:"indicator_data"`
 }
 


### PR DESCRIPTION
## Summary

- `V2MacroeconomicDetail` wire type gains `frequence` and `importance` fields
- `convertV2MacroeconomicDetail` now maps them to `MacroeconomicIndicator.Periodicity` and `.Importance`

Previously `Macroeconomic().Info.Periodicity` and `.Importance` were always empty/zero in the detail response, even though the list endpoint (`MacroeconomicIndicators`) returned these fields correctly.

## Test plan

- [ ] Call `Macroeconomic(indicatorCode, ...)` and verify `Info.Periodicity` and `Info.Importance` are now populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)