### PR TITLE
fix(alert): decode counter_id field correctly in AlertSymbolGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.25.2] - 2026-06-26
+
+### Fixed
+
+- `AlertContext.List`: `AlertSymbolGroup.Symbol` was always empty because the JSON tag was `"symbol"` but the API returns `"counter_id"` (e.g. `ST/HK/700`). Fixed by changing the tag to `json:"counter_id"` and converting via `counter.IDToSymbol()` so callers receive the standard symbol format (e.g. `700.HK`).
+- `FundamentalContext.Macroeconomic`: `Info.Periodicity` and `Info.Importance` were always zero/empty. Fixed by adding `frequence` and `importance` fields to the v2 wire type `V2MacroeconomicDetail`.
+
 ## [v0.25.1] - 2026-06-13
 
 ### Added

--- a/alert/context.go
+++ b/alert/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/longbridge/openapi-go/alert/jsontypes"
 	"github.com/longbridge/openapi-go/config"
 	httplib "github.com/longbridge/openapi-go/http"
+	"github.com/longbridge/openapi-go/internal/counter"
 )
 
 // AlertContext is a client for the Longbridge Price Alert OpenAPI.
@@ -131,7 +132,7 @@ func convertAlertList(j *jsontypes.AlertList) *AlertList {
 
 func convertAlertSymbolGroup(j *jsontypes.AlertSymbolGroup) *AlertSymbolGroup {
 	g := &AlertSymbolGroup{
-		Symbol:     j.Symbol,
+		Symbol:     counter.IDToSymbol(j.Symbol),
 		Code:       j.Code,
 		Market:     j.Market,
 		Name:       j.Name,

--- a/alert/jsontypes/types.go
+++ b/alert/jsontypes/types.go
@@ -13,9 +13,8 @@ type AlertList struct {
 
 // AlertSymbolGroup holds all alert items for a single security.
 type AlertSymbolGroup struct {
-	// Symbol is the security identifier (e.g. "700.HK").
-	// The API returns a counter_id; the Go layer stores it as the symbol string.
-	Symbol     string           `json:"symbol"`
+	// Symbol is the security identifier (e.g. "700.HK"), decoded from counter_id.
+	Symbol     string           `json:"counter_id"`
 	Code       string           `json:"code"`
 	Market     string           `json:"market"`
 	Name       string           `json:"name"`


### PR DESCRIPTION
## Summary

- `AlertSymbolGroup` in `alert/jsontypes/types.go` had `json:"symbol"` but the API returns `counter_id` (e.g. `ST/HK/700`), so `Symbol` was always empty string after deserialization
- Fix: change tag to `json:"counter_id"` and use `counter.IDToSymbol()` in `convertAlertSymbolGroup` to convert `ST/HK/700` → `700.HK`

## Root cause

The Rust SDK already handled this correctly with `rename = "counter_id", deserialize_with = "deserialize_counter_id_as_symbol"`. Only the Go SDK had the wrong JSON tag.

## Test plan

- [ ] Call `AlertContext.List()` and verify `AlertSymbolGroup.Symbol` is now populated (e.g. `700.HK`, `AAPL.US`) instead of empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)