### PR TITLE
fix(quote): skip nil entries in RealtimeQuote when cache is empty

### DIFF
--- a/quote/core.go
+++ b/quote/core.go
@@ -649,7 +649,9 @@ func (c *core) CalcIndex(ctx context.Context, symbols []string, indexes []CalcIn
 func (c *core) RealtimeQuote(ctx context.Context, symbols []string) (quotes []*Quote, err error) {
 	quotes = make([]*Quote, 0, len(symbols))
 	for _, symbol := range symbols {
-		quotes = append(quotes, c.store.GetQuote(symbol))
+		if q := c.store.GetQuote(symbol); q != nil {
+			quotes = append(quotes, q)
+		}
 	}
 	return
 }


### PR DESCRIPTION
## Problem

`RealtimeQuote` calls `store.GetQuote(symbol)` for each requested symbol. When no WebSocket push has been received yet (e.g. non-trading hours, or immediately after `Subscribe`), `GetQuote` returns `nil`. These nil entries were appended to the result slice, causing a **nil pointer dereference panic** on the caller side when ranging over the results:

```go
for _, s := range quotes {
    fmt.Println(s.Symbol) // panic: nil pointer dereference
}
```

## Fix

Skip nil entries so the returned slice only contains symbols that have cached data:

```go
if q := c.store.GetQuote(symbol); q != nil {
    quotes = append(quotes, q)
}
```

## Notes

- Rust SDK already handles this correctly with `if let Some(data)` — no change needed there
- Python / Node.js / Java are unaffected (they go through the Rust core)
- Only Go SDK was affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)