### PR TITLE
feat: reject non-standard symbols (missing CODE.MARKET format)

### DIFF
--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -108,6 +108,9 @@ func (c *FundamentalContext) FinancialReport(
 	kind FinancialReportKind,
 	period *FinancialReportPeriod,
 ) (*FinancialReports, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	kindStr := financialReportKindStr(kind)
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
@@ -168,6 +171,9 @@ func (c *FundamentalContext) InstitutionRating(
 	ctx context.Context,
 	symbol string,
 ) (*InstitutionRating, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	cid := symbolToCounterID(symbol)
 	q := url.Values{}
 	q.Set("counter_id", cid)
@@ -210,6 +216,9 @@ func (c *FundamentalContext) InstitutionRatingDetail(
 	ctx context.Context,
 	symbol string,
 ) (*InstitutionRatingDetail, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.InstitutionRatingDetail
@@ -228,6 +237,9 @@ func (c *FundamentalContext) Dividend(
 	ctx context.Context,
 	symbol string,
 ) (*DividendList, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.DividendList
@@ -244,6 +256,9 @@ func (c *FundamentalContext) DividendDetail(
 	ctx context.Context,
 	symbol string,
 ) (*DividendList, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.DividendList
@@ -262,6 +277,9 @@ func (c *FundamentalContext) ForecastEps(
 	ctx context.Context,
 	symbol string,
 ) (*ForecastEps, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.ForecastEps
@@ -280,6 +298,9 @@ func (c *FundamentalContext) Consensus(
 	ctx context.Context,
 	symbol string,
 ) (*FinancialConsensus, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.FinancialConsensus
@@ -298,6 +319,9 @@ func (c *FundamentalContext) Valuation(
 	ctx context.Context,
 	symbol string,
 ) (*ValuationData, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	q.Set("indicator", "pe")
@@ -316,6 +340,9 @@ func (c *FundamentalContext) ValuationHistory(
 	ctx context.Context,
 	symbol string,
 ) (*ValuationHistoryResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.ValuationHistoryResponse
@@ -334,6 +361,9 @@ func (c *FundamentalContext) IndustryValuation(
 	ctx context.Context,
 	symbol string,
 ) (*IndustryValuationList, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.IndustryValuationList
@@ -350,6 +380,9 @@ func (c *FundamentalContext) IndustryValuationDist(
 	ctx context.Context,
 	symbol string,
 ) (*IndustryValuationDist, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.IndustryValuationDist
@@ -368,6 +401,9 @@ func (c *FundamentalContext) Company(
 	ctx context.Context,
 	symbol string,
 ) (*CompanyOverview, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.CompanyOverview
@@ -386,6 +422,9 @@ func (c *FundamentalContext) Executive(
 	ctx context.Context,
 	symbol string,
 ) (*ExecutiveList, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_ids", symbolToCounterID(symbol))
 	var resp jsontypes.ExecutiveList
@@ -404,6 +443,9 @@ func (c *FundamentalContext) Shareholder(
 	ctx context.Context,
 	symbol string,
 ) (*ShareholderList, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.ShareholderList
@@ -422,6 +464,9 @@ func (c *FundamentalContext) FundHolder(
 	ctx context.Context,
 	symbol string,
 ) (*FundHolders, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.FundHolders
@@ -440,6 +485,9 @@ func (c *FundamentalContext) CorpAction(
 	ctx context.Context,
 	symbol string,
 ) (*CorpActions, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	q.Set("req_type", "1")
@@ -460,6 +508,9 @@ func (c *FundamentalContext) InvestRelation(
 	ctx context.Context,
 	symbol string,
 ) (*InvestRelations, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	q.Set("count", "0")
@@ -479,6 +530,9 @@ func (c *FundamentalContext) Operating(
 	ctx context.Context,
 	symbol string,
 ) (*OperatingList, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	// Operating reports are served only by the AP data center.
 	if err := c.httpClient.CheckRegion("/v1/quote/operatings", "AP"); err != nil {
 		return nil, err
@@ -501,6 +555,9 @@ func (c *FundamentalContext) Buyback(
 	ctx context.Context,
 	symbol string,
 ) (*BuybackData, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.BuybackData
@@ -519,6 +576,9 @@ func (c *FundamentalContext) Ratings(
 	ctx context.Context,
 	symbol string,
 ) (*StockRatings, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.StockRatings
@@ -1117,6 +1177,9 @@ func (c *FundamentalContext) ShareholderTop(
 	ctx context.Context,
 	symbol string,
 ) (*ShareholderTopResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp json.RawMessage
@@ -1136,6 +1199,9 @@ func (c *FundamentalContext) ShareholderDetail(
 	symbol string,
 	objectID int64,
 ) (*ShareholderDetailResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	q.Set("object_id", strconv.FormatInt(objectID, 10))
@@ -1162,6 +1228,9 @@ func (c *FundamentalContext) ValuationComparison(
 	currency string,
 	comparisonSymbols []string,
 ) (*ValuationComparisonResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	counterIDs := make([]string, 0, len(comparisonSymbols))
 	for _, s := range comparisonSymbols {
 		counterIDs = append(counterIDs, symbolToCounterID(s))
@@ -1246,6 +1315,9 @@ func (c *FundamentalContext) EtfAssetAllocation(
 	ctx context.Context,
 	symbol string,
 ) (*AssetAllocationResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", counterpkg.SymbolToCounterID(symbol))
 	var resp jsontypes.AssetAllocationResponse
@@ -1324,6 +1396,9 @@ func (c *FundamentalContext) BusinessSegments(
 	ctx context.Context,
 	symbol string,
 ) (*BusinessSegments, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.BusinessSegments
@@ -1343,6 +1418,9 @@ func (c *FundamentalContext) BusinessSegmentsHistory(
 	report string,
 	cate string,
 ) (*BusinessSegmentsHistory, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	if report != "" {
@@ -1368,6 +1446,9 @@ func (c *FundamentalContext) InstitutionRatingViews(
 	ctx context.Context,
 	symbol string,
 ) (*InstitutionRatingViews, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	var resp jsontypes.InstitutionRatingViews
@@ -1449,6 +1530,9 @@ func (c *FundamentalContext) FinancialReportSnapshot(
 	fiscalYear int,
 	fiscalPeriod string,
 ) (*FinancialReportSnapshot, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", symbolToCounterID(symbol))
 	if report != "" {

--- a/fundamental/context.go
+++ b/fundamental/context.go
@@ -63,6 +63,15 @@ func symbolToCounterID(symbol string) string { return counter.SymbolToID(symbol)
 
 func counterIDToSymbol(counterID string) string { return counter.IDToSymbol(counterID) }
 
+// checkSymbol validates that symbol is in CODE.MARKET format and returns
+// the corresponding counter_id. Returns an error for bare tickers like "AXTI".
+func checkSymbol(symbol string) (string, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return "", err
+	}
+	return counter.SymbolToID(symbol), nil
+}
+
 // decimalFromString parses a decimal string; returns nil for empty strings or
 // unparseable values.
 func decimalFromString(s string) *decimal.Decimal {

--- a/fundamental/us_context.go
+++ b/fundamental/us_context.go
@@ -14,8 +14,12 @@ func (c *FundamentalContext) CompanyOverview(ctx context.Context, symbol string)
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/company-overview", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	var resp USCompanyOverview
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/company-overview", q, &resp); err != nil {
 		return nil, err
@@ -31,8 +35,12 @@ func (c *FundamentalContext) ValuationOverview(ctx context.Context, symbol strin
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/valuation-overview", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	var resp ValuationOverview
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/valuation-overview", q, &resp); err != nil {
 		return nil, err
@@ -51,8 +59,12 @@ func (c *FundamentalContext) FinancialOverview(ctx context.Context, symbol, repo
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/finn-overview", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	q.Set("report", report)
 	var resp FinancialOverview
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/finn-overview", q, &resp); err != nil {
@@ -74,8 +86,12 @@ func (c *FundamentalContext) FinancialStatement(ctx context.Context, symbol, kin
 	if err := c.httpClient.CheckRegion("/v1/us/quote/financials/statements", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	q.Set("kind", kind)
 	q.Set("report", report)
 	var resp FinancialStatement
@@ -96,8 +112,12 @@ func (c *FundamentalContext) KeyFinancialMetrics(ctx context.Context, symbol, re
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/fin-keyfactor", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	q.Set("report", report)
 	var resp KeyFinancialMetrics
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/fin-keyfactor", q, &resp); err != nil {
@@ -117,8 +137,12 @@ func (c *FundamentalContext) AnalystConsensus(ctx context.Context, symbol, repor
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/fin-consensus", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	q.Set("report", report)
 	var resp AnalystConsensus
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/fin-consensus", q, &resp); err != nil {
@@ -135,8 +159,12 @@ func (c *FundamentalContext) ETFDividendInfo(ctx context.Context, symbol string)
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/etf-dividend-info", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	var resp ETFDividendInfo
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/etf-dividend-info", q, &resp); err != nil {
 		return nil, err
@@ -152,8 +180,12 @@ func (c *FundamentalContext) CompanyDividends(ctx context.Context, symbol string
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/company-dividends", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	var resp USCompanyDividends
 	if err := c.httpClient.Get(ctx, "/v1/us/stock-info/company-dividends", q, &resp); err != nil {
 		return nil, err
@@ -171,8 +203,12 @@ func (c *FundamentalContext) ETFFiles(ctx context.Context, symbol string, size *
 	if err := c.httpClient.CheckRegion("/v1/us/stock-info/etf-files", "US"); err != nil {
 		return nil, err
 	}
+	cid, err := checkSymbol(symbol)
+	if err != nil {
+		return nil, err
+	}
 	q := url.Values{}
-	q.Set("counter_id", symbolToCounterID(symbol))
+	q.Set("counter_id", cid)
 	if size != nil {
 		q.Set("size", fmt.Sprintf("%d", *size))
 	}

--- a/internal/counter/counter.go
+++ b/internal/counter/counter.go
@@ -2,9 +2,21 @@ package counter
 
 import (
 	_ "embed"
+	"fmt"
 	"strings"
 	"sync"
 )
+
+// ValidateSymbol returns an error if symbol is not in the expected
+// CODE.MARKET format (e.g. "AAPL.US", "BTCUSD.BKKT").
+// Both the code and market parts must be non-empty.
+func ValidateSymbol(symbol string) error {
+	idx := strings.LastIndex(symbol, ".")
+	if idx <= 0 || idx == len(symbol)-1 {
+		return fmt.Errorf("invalid symbol %q: expected CODE.MARKET format (e.g. \"AAPL.US\")", symbol)
+	}
+	return nil
+}
 
 //go:embed US-ETF.csv
 var usEtfCSV string

--- a/internal/counter/counter_test.go
+++ b/internal/counter/counter_test.go
@@ -2,24 +2,23 @@ package counter
 
 import "testing"
 
-func TestIDToSymbol(t *testing.T) {
-	cases := []struct {
-		in   string
-		want string
+func TestValidateSymbol(t *testing.T) {
+	tests := []struct {
+		symbol  string
+		wantErr bool
 	}{
-		{"ST/US/TSLA", "TSLA.US"},
-		{"ST/HK/700", "700.HK"},
-		{"ST/SH/600519", "600519.SH"},
-		{"ST/SZ/000001", "000001.SZ"},
-		{"IX/HK/HSI", "HSI.HK"},
-		// non-slash formats returned unchanged
-		{"AAPL.US", "AAPL.US"},
-		{"", ""},
+		{"AAPL.US", false},
+		{"SPY.US", false},
+		{"BTCUSD.BKKT", false},
+		{"AXTI", true},        // no dot
+		{"", true},            // empty
+		{".US", true},         // empty code
+		{"AAPL.", true},       // empty market
 	}
-	for _, c := range cases {
-		got := IDToSymbol(c.in)
-		if got != c.want {
-			t.Errorf("IDToSymbol(%q) = %q, want %q", c.in, got, c.want)
+	for _, tt := range tests {
+		err := ValidateSymbol(tt.symbol)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ValidateSymbol(%q) error = %v, wantErr %v", tt.symbol, err, tt.wantErr)
 		}
 	}
 }

--- a/quote/context.go
+++ b/quote/context.go
@@ -152,6 +152,9 @@ func (c *QuoteContext) WarrantQuote(ctx context.Context, symbols []string) (warr
 //	qctx, err := quote.NewFromEnv()
 //	depth, err := qctx.Depth(context.Background(), []string{"AAPL.HK"})
 func (c *QuoteContext) Depth(ctx context.Context, symbol string) (securityDepth *SecurityDepth, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.Depth(ctx, symbol)
 }
 
@@ -163,6 +166,9 @@ func (c *QuoteContext) Depth(ctx context.Context, symbol string) (securityDepth 
 //	qctx, err := quote.NewFromEnv()
 //	brokers, err := qctx.Brokers(context.Background(), "AAPL.HK")
 func (c *QuoteContext) Brokers(ctx context.Context, symbol string) (securityBrokers *SecurityBrokers, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	// Broker queue via WebSocket is served only by the AP data center.
 	if err = c.opts.httpClient.CheckRegion("quote/brokers (WebSocket)", "AP"); err != nil {
 		return
@@ -189,6 +195,9 @@ func (c *QuoteContext) Participants(ctx context.Context) (infos []*ParticipantIn
 //	qctx, err := quote.NewFromEnv()
 //	trades, err := qctx.Trades(context.Background())
 func (c *QuoteContext) Trades(ctx context.Context, symbol string, count int32) (trades []*Trade, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.Trades(ctx, symbol, count)
 }
 
@@ -199,6 +208,9 @@ func (c *QuoteContext) Trades(ctx context.Context, symbol string, count int32) (
 //	qctx, err := quote.NewFromEnv()
 //	trades, err := qctx.Intraday(context.Background(), "AAPL.US")
 func (c *QuoteContext) Intraday(ctx context.Context, symbol string) (lines []*IntradayLine, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.Intraday(ctx, symbol)
 }
 
@@ -223,6 +235,9 @@ func (c *QuoteContext) Intraday(ctx context.Context, symbol string) (lines []*In
 //	qctx, err := quote.NewFromEnv()
 //	klines, err := qctx.Candlesticks(context.Background(), "AAPL.US", quote.PeriodDay, 10, quote.AdjustTypeNo)
 func (c *QuoteContext) Candlesticks(ctx context.Context, symbol string, period Period, count int32, adjustType AdjustType) (sticks []*Candlestick, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.Candlesticks(ctx, symbol, period, count, adjustType)
 }
 
@@ -248,6 +263,9 @@ func (c *QuoteContext) Candlesticks(ctx context.Context, symbol string, period P
 //	dateTime := time.Date(2022, 5, 10, 11, 10, 0, 0, time.UTC)
 //	klines, err := qctx.HistoryCandlesticksByOffset(context.Background(), "AAPL.US", quote.PeriodDay, quote.AdjustTypeNo, true, &dateTime, 100)
 func (c *QuoteContext) HistoryCandlesticksByOffset(ctx context.Context, symbol string, period Period, adjustType AdjustType, isForward bool, dateTime *time.Time, count int32, opts ...CandlestickRequestOption) (sticks []*Candlestick, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.HistoryCandlesticksByOffset(ctx, symbol, period, adjustType, isForward, dateTime, count, opts...)
 }
 
@@ -274,6 +292,9 @@ func (c *QuoteContext) HistoryCandlesticksByOffset(ctx context.Context, symbol s
 //	endDate := time.Date(2022, 6, 10, 0, 0, 0, 0, time.UTC)
 //	klines, err := qctx.HistoryCandlesticksByDate(context.Background(), "AAPL.US", quote.PeriodDay, quote.AdjustTypeNo, &startDate, &endDate)
 func (c *QuoteContext) HistoryCandlesticksByDate(ctx context.Context, symbol string, period Period, adjustType AdjustType, startDate *time.Time, endDate *time.Time, opts ...CandlestickRequestOption) (sticks []*Candlestick, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.HistoryCandlesticksByDate(ctx, symbol, period, adjustType, startDate, endDate, opts...)
 }
 
@@ -285,6 +306,9 @@ func (c *QuoteContext) HistoryCandlesticksByDate(ctx context.Context, symbol str
 //	qctx, err := quote.NewFromEnv()
 //	list, err := qctx.OptionChainExpiryDateList(context.Background(), "AAPL.US")
 func (c *QuoteContext) OptionChainExpiryDateList(ctx context.Context, symbol string) (times []time.Time, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.OptionChainExpiryDateList(ctx, symbol)
 }
 
@@ -297,6 +321,9 @@ func (c *QuoteContext) OptionChainExpiryDateList(ctx context.Context, symbol str
 //	date := time.Date(2022, 5, 10, 0, 0, 0, 0, time.UTC)
 //	list, err := qctx.OptionChainInfoByDate(context.Background(), "AAPL.US", &date)
 func (c *QuoteContext) OptionChainInfoByDate(ctx context.Context, symbol string, expiryDate *time.Time) (strikePriceInfos []*StrikePriceInfo, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.OptionChainInfoByDate(ctx, symbol, expiryDate)
 }
 
@@ -325,6 +352,9 @@ func (c *QuoteContext) WarrantIssuers(ctx context.Context) (infos []*IssuerInfo,
 //	  Type: []quote.WarrantType{quote.WarrantCall, quote.WarrantPut},
 //	}, quote. WarrantZH_CN)
 func (c *QuoteContext) WarrantList(ctx context.Context, symbol string, config WarrantFilter, lang WarrantLanguage) (infos []*WarrantInfo, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.WarrantList(ctx, symbol, config, lang)
 }
 
@@ -360,6 +390,9 @@ func (c *QuoteContext) TradingDays(ctx context.Context, market openapi.Market, b
 //	qctx, err := quote.NewFromEnv()
 //	dist, err := qctx.CapitalDistribution(context.Background(), "700.HK")
 func (c *QuoteContext) CapitalDistribution(ctx context.Context, symbol string) (capitalDib CapitalDistribution, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.CapitalDistribution(ctx, symbol)
 }
 
@@ -371,6 +404,9 @@ func (c *QuoteContext) CapitalDistribution(ctx context.Context, symbol string) (
 //	qctx, err := quote.NewFromEnv()
 //	flowlines, err := qctx.CapitalFlow(context.Background(), "700.HK")
 func (c *QuoteContext) CapitalFlow(ctx context.Context, symbol string) (capitalFlowLines []CapitalFlowLine, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	return c.core.CapitalFlow(ctx, symbol)
 }
 
@@ -402,6 +438,9 @@ func (c *QuoteContext) RealtimeQuote(ctx context.Context, symbols []string) ([]*
 //	qctx, err := quote.NewFromEnv()
 //	depth, err := qctx.RealtimeDepth(context.Background(), "700.HK")
 func (c *QuoteContext) RealtimeDepth(ctx context.Context, symbol string) (*SecurityDepth, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	return c.core.RealtimeDepth(ctx, symbol)
 }
 
@@ -412,6 +451,9 @@ func (c *QuoteContext) RealtimeDepth(ctx context.Context, symbol string) (*Secur
 //	qctx, err := quote.NewFromEnv()
 //	trades, err := qctx.RealtimeTrades(context.Background(), "700.HK")
 func (c *QuoteContext) RealtimeTrades(ctx context.Context, symbol string) ([]*Trade, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	return c.core.RealtimeTrades(ctx, symbol)
 }
 
@@ -422,6 +464,9 @@ func (c *QuoteContext) RealtimeTrades(ctx context.Context, symbol string) ([]*Tr
 //	qctx, err := quote.NewFromEnv()
 //	brokers, err := qctx.RealtimeBrokers(context.Background(), "700.HK")
 func (c *QuoteContext) RealtimeBrokers(ctx context.Context, symbol string) (*SecurityBrokers, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	return c.core.RealtimeBrokers(ctx, symbol)
 }
 
@@ -510,6 +555,9 @@ func (c *QuoteContext) WatchedGroups(ctx context.Context) (groupList []*WatchedG
 
 // Filings returns the filings list for a symbol.
 func (c *QuoteContext) Filings(ctx context.Context, symbol string) (items []*FilingItem, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	var resp jsontypes.FilingList
 	values := url.Values{}
 	values.Add("symbol", symbol)
@@ -539,6 +587,9 @@ func (c *QuoteContext) Filings(ctx context.Context, symbol string) (items []*Fil
 //
 // count controls the number of records returned (1–100, default 20).
 func (c *QuoteContext) ShortPositions(ctx context.Context, symbol string, count uint32) (*ShortPositionsResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	isHK := strings.HasSuffix(strings.ToUpper(symbol), ".HK")
 	path := "/v1/quote/short-positions/us"
 	if isHK {
@@ -576,6 +627,9 @@ func (c *QuoteContext) ShortPositions(ctx context.Context, symbol string, count 
 // OptionVolume returns aggregated call/put volume stats for a security.
 // Path: GET /v1/quote/option-volume-stats
 func (c *QuoteContext) OptionVolume(ctx context.Context, symbol string) (*OptionVolumeStats, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	var resp jsontypes.OptionVolumeStats
 	values := url.Values{}
 	values.Add("symbol", symbol)
@@ -591,6 +645,9 @@ func (c *QuoteContext) OptionVolume(ctx context.Context, symbol string) (*Option
 // OptionVolumeDaily returns daily option volume data for a security within a time range.
 // Path: GET /v1/quote/option-volume-stats/daily
 func (c *QuoteContext) OptionVolumeDaily(ctx context.Context, symbol string, start time.Time, end time.Time) ([]*DailyOptionVolume, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	var resp jsontypes.OptionVolumeDaily
 	values := url.Values{}
 	values.Add("symbol", symbol)
@@ -703,6 +760,9 @@ func New(opt ...Option) (*QuoteContext, error) {
 //   - ".HK" → GET /v1/quote/short-trades/hk
 //   - ".US" → GET /v1/quote/short-trades/us
 func (c *QuoteContext) ShortTrades(ctx context.Context, symbol string, count uint32) (*ShortTradesResponse, error) {
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	values := url.Values{}
 	values.Set("counter_id", quoteSymbolToCounterID(symbol))
 	values.Set("last_timestamp", fmt.Sprintf("%d", time.Now().Unix()))

--- a/quote/us_context.go
+++ b/quote/us_context.go
@@ -60,6 +60,9 @@ func (c *QuoteContext) CryptoOverview(ctx context.Context, symbol string) (*Cryp
 	if err := c.opts.httpClient.CheckRegion("/v1/us/gemini/crypto-overview", "US"); err != nil {
 		return nil, err
 	}
+	if err := counter.ValidateSymbol(symbol); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	q.Set("counter_id", counter.SymbolToID(symbol))
 	var raw cryptoRawOverview

--- a/trade/context.go
+++ b/trade/context.go
@@ -3,6 +3,8 @@ package trade
 
 import (
 	"context"
+
+	"github.com/longbridge/openapi-go/internal/counter"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -320,6 +322,9 @@ func (c *TradeContext) StockPositions(ctx context.Context, symbols []string) (st
 //	tctx, err := trade.NewFromCfg(conf)
 //	mr, err := tctx.MarginRatio(context.Background(), "AAPL.US")
 func (c *TradeContext) MarginRatio(ctx context.Context, symbol string) (marginRatio MarginRatio, err error) {
+	if err = counter.ValidateSymbol(symbol); err != nil {
+		return
+	}
 	values := url.Values{}
 	values.Add("symbol", symbol)
 	var resp jsontypes.MarginRatio

--- a/trade/us_context.go
+++ b/trade/us_context.go
@@ -101,6 +101,9 @@ func (c *TradeContext) QueryUSOrders(ctx context.Context, req *GetUSHistoryOrder
 	// Build counter_ids from Symbol
 	counterIDs := []string{}
 	if req.Symbol != "" {
+		if err := counter.ValidateSymbol(req.Symbol); err != nil {
+			return nil, err
+		}
 		counterIDs = append(counterIDs, counter.SymbolToID(req.Symbol))
 	}
 


### PR DESCRIPTION
## Summary

- Add `ValidateSymbol(symbol string) error` to `internal/counter` — rejects bare tickers like `"AXTI"` that are missing the required `CODE.MARKET` format (e.g. `"AAPL.US"`)
- Add `checkSymbol(symbol string) (string, error)` helper in `fundamental` — validates + converts to counter_id in one step
- Apply validation to **all** SDK methods that accept a single symbol parameter:
  - 9 US fundamental methods (`CompanyOverview`, `ValuationOverview`, `FinancialStatement`, etc.)
  - 28 non-US fundamental methods (`InstitutionRating`, `Dividend`, `Company`, etc.)
  - 20 quote methods (`Depth`, `Brokers`, `Trades`, `Candlesticks`, `OptionVolume`, etc.)
  - `CryptoOverview` (US quote)
  - `MarginRatio` (trade)
  - `QueryUSOrders` optional symbol filter (validates only when non-empty)

## Error message

```
invalid symbol "AXTI": expected CODE.MARKET format (e.g. "AAPL.US")
```

## Test plan

- [x] `TestValidateSymbol` unit test — 7 cases covering valid/invalid symbols
- [x] Integration test: bare tickers rejected before any network call
- [x] Integration test: `AAPL.US`, `SPY.US` accepted and return data
- [x] Integration test: `QueryUSOrders` with no symbol still works (optional field)