### PR TITLE
feat(agent): add FurtherQuestions to ConversationResponse

### DIFF
--- a/agent/stream.go
+++ b/agent/stream.go
@@ -208,12 +208,13 @@ func (s *ConversationStream) decodeEvent(payload string) (ConversationStreamEven
 			answer = *payload.Outputs.Answer
 		}
 		resp := &ConversationResponse{
-			Status:      payload.Status,
-			Answer:      answer,
-			References:  payload.Outputs.References,
-			ElapsedTime: payload.ElapsedTime,
-			Interrupt:   payload.Outputs.Interrupt,
-			Error:       payload.Outputs.Error,
+			Status:           payload.Status,
+			Answer:           answer,
+			References:       payload.Outputs.References,
+			FurtherQuestions: payload.Outputs.FurtherQuestions,
+			ElapsedTime:      payload.ElapsedTime,
+			Interrupt:        payload.Outputs.Interrupt,
+			Error:            payload.Outputs.Error,
 		}
 		if s.started != nil {
 			resp.ChatUID = s.started.ChatUID

--- a/agent/stream_test.go
+++ b/agent/stream_test.go
@@ -23,7 +23,7 @@ const (
 	messageFrame          = `{"event":"message","workflow_run_id":"wr_1","data":{"text":"Tesla"}}`
 	pingFrame             = `{"event":"ping","workflow_run_id":"wr_1","data":null}`
 	chatFinishedFrame     = `{"event":"chat_finished","workflow_run_id":"wr_1","data":{"chat_id":834552,"chat_uid":"ct_9f2c1a5b","error":"","error_message":"","message_id":42}}`
-	workflowFinishedFrame = `{"event":"workflow_finished","workflow_run_id":"wr_1","data":{"status":"succeeded","elapsed_time":3.21,"outputs":{"answer":"Tesla (TSLA.US) recently..."}}}`
+	workflowFinishedFrame = `{"event":"workflow_finished","workflow_run_id":"wr_1","data":{"status":"succeeded","elapsed_time":3.21,"outputs":{"answer":"Tesla (TSLA.US) recently...","further_questions":["What is Tesla's P/E?","How did Q3 deliveries look?"]}}}`
 	chatTitleUpdatedFrame = `{"event":"chat_title_updated","workflow_run_id":"wr_1","data":{"chat_id":834552,"chat_uid":"ct_9f2c1a5b","source":"ai_generated","title":"Tesla stock performance","updated_at":1784546957}}`
 
 	// From https://open.longbridge.com/en/docs/ai/chat/events: the interrupt
@@ -126,6 +126,9 @@ func TestConversationStreamFullSequence(t *testing.T) {
 	}
 	if workflowFinished.Answer != "Tesla (TSLA.US) recently..." {
 		t.Errorf("Answer = %q", workflowFinished.Answer)
+	}
+	if len(workflowFinished.FurtherQuestions) != 2 || workflowFinished.FurtherQuestions[0] != "What is Tesla's P/E?" {
+		t.Errorf("FurtherQuestions = %+v", workflowFinished.FurtherQuestions)
 	}
 
 	// Arrives *after* workflow_finished in this (real, observed) ordering.

--- a/agent/types.go
+++ b/agent/types.go
@@ -170,6 +170,9 @@ type ConversationResponse struct {
 	Answer string `json:"answer"`
 	// References are sources referenced by the answer; nil if none.
 	References []Reference `json:"references"`
+	// FurtherQuestions are suggested follow-up questions ("you might also
+	// ask"); nil if none.
+	FurtherQuestions []string `json:"further_questions"`
 	// ElapsedTime is the run duration in seconds.
 	ElapsedTime float64 `json:"elapsed_time"`
 	// Interrupt is present only when Status is ConversationStatusInterrupted.
@@ -184,14 +187,15 @@ type ConversationResponse struct {
 // it the numeric form seen in some SSE payloads (see ChatStartedEvent).
 func (r *ConversationResponse) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		ChatUID     string             `json:"chat_uid"`
-		MessageID   json.RawMessage    `json:"message_id"`
-		Status      ConversationStatus `json:"status"`
-		Answer      string             `json:"answer"`
-		References  []Reference        `json:"references"`
-		ElapsedTime float64            `json:"elapsed_time"`
-		Interrupt   *Interrupt         `json:"interrupt"`
-		Error       *ConversationError `json:"error"`
+		ChatUID          string             `json:"chat_uid"`
+		MessageID        json.RawMessage    `json:"message_id"`
+		Status           ConversationStatus `json:"status"`
+		Answer           string             `json:"answer"`
+		References       []Reference        `json:"references"`
+		FurtherQuestions []string           `json:"further_questions"`
+		ElapsedTime      float64            `json:"elapsed_time"`
+		Interrupt        *Interrupt         `json:"interrupt"`
+		Error            *ConversationError `json:"error"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -205,6 +209,7 @@ func (r *ConversationResponse) UnmarshalJSON(data []byte) error {
 	r.Status = raw.Status
 	r.Answer = raw.Answer
 	r.References = raw.References
+	r.FurtherQuestions = raw.FurtherQuestions
 	r.ElapsedTime = raw.ElapsedTime
 	r.Interrupt = raw.Interrupt
 	r.Error = raw.Error
@@ -440,6 +445,9 @@ type workflowOutputs struct {
 	Answer *string `json:"answer"`
 	// References are sources referenced by the answer.
 	References []Reference `json:"references"`
+	// FurtherQuestions are suggested follow-up questions ("you might also
+	// ask").
+	FurtherQuestions []string `json:"further_questions"`
 	// Interrupt is present only when the status is "interrupted".
 	Interrupt *Interrupt `json:"interrupt"`
 	// Error is present only when the run failed.

--- a/agent/types_test.go
+++ b/agent/types_test.go
@@ -15,6 +15,10 @@ const succeededJSON = `{
 	"references": [
 		{ "index": 1, "title": "...", "url": "..." }
 	],
+	"further_questions": [
+		"What is Tesla's P/E?",
+		"How did Q3 deliveries look?"
+	],
 	"elapsed_time": 3.21
 }`
 
@@ -63,6 +67,9 @@ func TestUnmarshalSucceededConversationResponse(t *testing.T) {
 	}
 	if len(resp.References) != 1 || resp.References[0].Index != 1 {
 		t.Errorf("References = %+v", resp.References)
+	}
+	if len(resp.FurtherQuestions) != 2 || resp.FurtherQuestions[0] != "What is Tesla's P/E?" {
+		t.Errorf("FurtherQuestions = %+v", resp.FurtherQuestions)
 	}
 	if resp.ElapsedTime != 3.21 {
 		t.Errorf("ElapsedTime = %v", resp.ElapsedTime)


### PR DESCRIPTION
## What

The agent `workflow_finished` event's `outputs` carry a `further_questions` list — the "you might also ask" follow-up suggestions — that the Go SDK dropped. `ConversationResponse` and the internal `workflowOutputs` only modeled `answer`/`references`, so the field was lost on both the blocking response and the streamed `WorkflowFinishedEvent`.

## Change

- Add `FurtherQuestions []string` (`json:"further_questions"`) to `ConversationResponse` and its `UnmarshalJSON` raw struct.
- Add it to the internal `workflowOutputs` and thread it through the `workflow_finished` fold in `stream.go`.

## Tests

Extended the blocking `TestUnmarshalSucceededConversationResponse` and the streamed `workflow_finished` assertion to cover `FurtherQuestions`. `go test ./agent/`, `go vet`, and `gofmt` all clean.

Companion to longbridge/openapi#564 (same field across the other language SDKs).