### PR TITLE
feat(agent): capture full Reference content and ChatStartedEvent fields

### DIFF
--- a/agent/types.go
+++ b/agent/types.go
@@ -98,10 +98,21 @@ const (
 type Reference struct {
 	// Index is the reference index.
 	Index int32 `json:"index"`
-	// Title is the reference title.
+	// OriginalIndex is the index in the source list before any reranking.
+	OriginalIndex int32 `json:"original_index"`
+	// RefType is the reference kind, e.g. "NewsArticle".
+	RefType string `json:"type"`
+	// ID is the reference id.
+	ID string `json:"id"`
+	// Title is the reference title. Often empty at the top level — the
+	// human-readable title usually lives in Content.
 	Title string `json:"title"`
-	// URL is the reference URL.
+	// URL is the reference URL. Often empty at the top level — see Content.
 	URL string `json:"url"`
+	// Content is the full reference payload as sent by the server (source,
+	// description, published_at, source_url, source_logo, kind, …), kept as
+	// raw JSON because the field set varies by RefType. nil if absent.
+	Content json.RawMessage `json:"content"`
 }
 
 // QuestionOption is one option of a Question.
@@ -253,6 +264,12 @@ type ChatStartedEvent struct {
 	ChatUID string `json:"chat_uid"`
 	// MessageID is the message ID of this round.
 	MessageID string `json:"message_id"`
+	// ChatID is the ID of the owning conversation.
+	ChatID int64 `json:"chat_id"`
+	// Error is the error detail; empty at start.
+	Error string `json:"error"`
+	// ErrorMessage is the user-facing error message; empty at start.
+	ErrorMessage string `json:"error_message"`
 }
 
 func (*ChatStartedEvent) conversationStreamEvent() {}
@@ -262,8 +279,11 @@ func (*ChatStartedEvent) conversationStreamEvent() {}
 // blocking response's top-level message_id, which is a quoted string.
 func (e *ChatStartedEvent) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		ChatUID   string          `json:"chat_uid"`
-		MessageID json.RawMessage `json:"message_id"`
+		ChatUID      string          `json:"chat_uid"`
+		MessageID    json.RawMessage `json:"message_id"`
+		ChatID       int64           `json:"chat_id"`
+		Error        string          `json:"error"`
+		ErrorMessage string          `json:"error_message"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -274,6 +294,9 @@ func (e *ChatStartedEvent) UnmarshalJSON(data []byte) error {
 	}
 	e.ChatUID = raw.ChatUID
 	e.MessageID = messageID
+	e.ChatID = raw.ChatID
+	e.Error = raw.Error
+	e.ErrorMessage = raw.ErrorMessage
 	return nil
 }
 

--- a/agent/types_test.go
+++ b/agent/types_test.go
@@ -121,6 +121,37 @@ func TestUnmarshalInterruptedConversationResponse(t *testing.T) {
 	}
 }
 
+func TestUnmarshalReferenceWithContent(t *testing.T) {
+	// The real wire reference nests human-readable fields under `content`
+	// and carries type/id/original_index; only `index` overlaps the old shape.
+	const j = `{"type":"NewsArticle","id":"295354885","index":1,"original_index":10,"content":{"source":"Zhitong","published_at":"2026-08-10T03:45:02Z"}}`
+	var r Reference
+	if err := json.Unmarshal([]byte(j), &r); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if r.Index != 1 || r.OriginalIndex != 10 || r.RefType != "NewsArticle" || r.ID != "295354885" {
+		t.Errorf("Reference = %+v", r)
+	}
+	var content map[string]any
+	if err := json.Unmarshal(r.Content, &content); err != nil {
+		t.Fatalf("content unmarshal error: %v", err)
+	}
+	if content["source"] != "Zhitong" {
+		t.Errorf("content.source = %v", content["source"])
+	}
+}
+
+func TestUnmarshalChatStartedEventFields(t *testing.T) {
+	const j = `{"chat_uid":"ct_1","message_id":42,"chat_id":1001,"error":"","error_message":""}`
+	var e ChatStartedEvent
+	if err := json.Unmarshal([]byte(j), &e); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if e.ChatUID != "ct_1" || e.MessageID != "42" || e.ChatID != 1001 {
+		t.Errorf("ChatStartedEvent = %+v", e)
+	}
+}
+
 func TestUnmarshalWorkspacesResponse(t *testing.T) {
 	const j = `{
 		"workspaces": [


### PR DESCRIPTION
## What

Audited the agent SSE wire against the Go structs and closed the fields the SDK was dropping.

- **`Reference`**: the real reference nests human-readable fields under a `content` object (`source`, `description`, `published_at`, `source_url`, …) and carries `type`/`id`/`original_index` at the top level. The SDK modeled only a flat `{index,title,url}`, so `title`/`url` were empty for real data and everything else was **lost**. Add `OriginalIndex`, `RefType` (json `"type"`), `ID`, and `Content json.RawMessage` (kept raw since the field set varies by `RefType`). Fixes references on `ConversationResponse` and the message / node-tool / workflow outputs.
- **`ChatStartedEvent`**: add `ChatID` / `Error` / `ErrorMessage` (present on the wire, mirroring `ChatFinishedEvent`), threaded through the custom `UnmarshalJSON`.

## Tests

`TestUnmarshalReferenceWithContent` + `TestUnmarshalChatStartedEventFields`. `go test ./agent/`, `go vet`, `gofmt` clean.

Companion to the same change across the other language SDKs (longbridge/openapi).