### PR TITLE
feat(agent): add Chats and Chat-detail endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **AI Agent:** add `AgentContext.Chats` (`GET /v1/ai/chats`) and `AgentContext.Chat` (`GET /v1/ai/chats/{chatUID}`) — list the account's chats (conversations) across Agents (optional `Page` / `Limit` / `ExcludeAgentUIDs` via `GetChatsOptions`), and fetch a single chat's detail with its messages. New types: `Chat`, `ChatsResponse`, `ChatMessage`, `ChatMessageChunk`, `ChatInfo`, `ChatDetail`, `GetChatsOptions`. The deeply-nested `ChatRelation` and message `Extends` are kept as raw JSON (`json.RawMessage`)
 - **Grid trading** — new `grid.GridContext` for grid-order management: `Submit` / `Replace` / `Cancel` / `Suspend` / `Restart` grid orders, `List` (paged) and `ListByIds`, `Detail` and `TriggerHistory`, `SubmitStrategyQuestionnaire` (strategy risk-disclosure), and `SymbolInfo` (returns `GridSymbolInfo`: name, last price, lot sizes, price-step rules, channel/authorization) — the security info needed to build a grid order
 - **AI Agent:** `agent.Interrupt` now exposes `Interactions` — a slice of the new `agent.HumanInteraction` type (`ToolCallID`, `InterruptID`, `InteractionType`, `ToolName`, `Questions`, and the raw `ToolArgs`) — and `agent.QuestionOption` now exposes `Label`. A `null` `questions` / `interactions` list from the server is tolerated (decodes to an empty slice)
 - **Attached order (take-profit / stop-loss) support** for `SubmitOrder` and `ReplaceOrder`:

--- a/agent/context.go
+++ b/agent/context.go
@@ -109,6 +109,41 @@ func (c *AgentContext) Agents(ctx context.Context, workspaceID string, opts *Get
 	return &resp, nil
 }
 
+// Chats lists the current account's chats (conversations) across Agents.
+//
+// Path: GET /v1/ai/chats
+func (c *AgentContext) Chats(ctx context.Context, opts *GetChatsOptions) (*ChatsResponse, error) {
+	q := url.Values{}
+	if opts != nil {
+		if opts.Page > 0 {
+			q.Set("page", strconv.FormatInt(int64(opts.Page), 10))
+		}
+		if opts.Limit > 0 {
+			q.Set("limit", strconv.FormatInt(int64(opts.Limit), 10))
+		}
+		if opts.ExcludeAgentUIDs != "" {
+			q.Set("exclude_agent_uids", opts.ExcludeAgentUIDs)
+		}
+	}
+	var resp ChatsResponse
+	if err := c.httpClient.Get(ctx, "/v1/ai/chats", q, &resp, httplib.WithRequestTimeout(listTimeout)); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Chat gets the detail of a single chat, including its messages.
+//
+// Path: GET /v1/ai/chats/{chatUID}
+func (c *AgentContext) Chat(ctx context.Context, chatUID string) (*ChatDetail, error) {
+	path := "/v1/ai/chats/" + url.PathEscape(chatUID)
+	var resp ChatDetail
+	if err := c.httpClient.Get(ctx, path, url.Values{}, &resp, httplib.WithRequestTimeout(listTimeout)); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // Conversation asks a question to the specified Agent, blocking until the
 // run succeeds, is interrupted, or fails.
 //

--- a/agent/types.go
+++ b/agent/types.go
@@ -77,6 +77,126 @@ type GetAgentsOptions struct {
 	Name string
 }
 
+// Chat is a chat (conversation) with an Agent, as returned by
+// AgentContext.Chats.
+type Chat struct {
+	// ID is the chat ID.
+	ID int64 `json:"id"`
+	// UID is the chat UID, used as the path parameter of AgentContext.Chat.
+	UID string `json:"uid"`
+	// Name is the chat name (title).
+	Name string `json:"name"`
+	// AgentID is the ID of the Agent this chat belongs to.
+	AgentID int64 `json:"agent_id"`
+	// AgentName is the name of the Agent this chat belongs to.
+	AgentName string `json:"agent_name"`
+	// AgentUID is the UID of the Agent this chat belongs to.
+	AgentUID string `json:"agent_uid"`
+	// FromSource is the source the chat was created from, e.g. "api".
+	FromSource string `json:"from_source"`
+	// HasUnread reports whether the chat has unread messages.
+	HasUnread bool `json:"has_unread"`
+	// CreatedAt is the creation time, Unix timestamp in seconds.
+	CreatedAt int64 `json:"created_at"`
+	// UpdatedAt is the last updated time, Unix timestamp in seconds.
+	UpdatedAt int64 `json:"updated_at"`
+	// ChatRelation is the Agent / permission relation metadata, kept as raw
+	// JSON because the field set is UI-configuration detail that varies by
+	// Agent.
+	ChatRelation json.RawMessage `json:"chat_relation"`
+}
+
+// ChatsResponse is the response for AgentContext.Chats.
+type ChatsResponse struct {
+	// Chats is the chat list.
+	Chats []Chat `json:"chats"`
+}
+
+// GetChatsOptions holds the optional query parameters for AgentContext.Chats.
+// The zero value uses the server defaults.
+type GetChatsOptions struct {
+	// Page is the page number, starting at 1. 0 uses the server default.
+	Page int32
+	// Limit is the page size. 0 uses the server default.
+	Limit int32
+	// ExcludeAgentUIDs excludes chats belonging to the given Agent UIDs
+	// (comma-joined, e.g. "dsl_builder"). Empty omits the filter.
+	ExcludeAgentUIDs string
+}
+
+// ChatMessageChunk is one content chunk of a ChatMessage.
+type ChatMessageChunk struct {
+	// ChunkType is the chunk type, e.g. "text".
+	ChunkType string `json:"chunk_type"`
+	// Content is the chunk content.
+	Content string `json:"content"`
+	// Index is the index of the chunk within the message.
+	Index int32 `json:"index"`
+	// StartedAt is the start time, Unix timestamp in seconds.
+	StartedAt int64 `json:"started_at"`
+	// StoppedAt is the stop time, Unix timestamp in seconds.
+	StoppedAt int64 `json:"stopped_at"`
+}
+
+// ChatMessage is a message within a chat.
+type ChatMessage struct {
+	// ID is the message ID.
+	ID int64 `json:"id"`
+	// ChatID is the ID of the owning chat.
+	ChatID int64 `json:"chat_id"`
+	// ChatUID is the UID of the owning chat.
+	ChatUID string `json:"chat_uid"`
+	// AgentID is the ID of the Agent.
+	AgentID int64 `json:"agent_id"`
+	// AgentName is the name of the Agent.
+	AgentName string `json:"agent_name"`
+	// AgentUID is the UID of the Agent.
+	AgentUID string `json:"agent_uid"`
+	// Sender is the sender, e.g. "user" or "assistant".
+	Sender string `json:"sender"`
+	// Status is the message status.
+	Status int32 `json:"status"`
+	// Likes is the number of likes.
+	Likes int32 `json:"likes"`
+	// ParentMessageID is the ID of the parent message; 0 if none.
+	ParentMessageID int64 `json:"parent_message_id"`
+	// ThinkingSeconds is the thinking time in seconds.
+	ThinkingSeconds int32 `json:"thinking_seconds"`
+	// ErrorCode is the error code; 0 if none.
+	ErrorCode int32 `json:"error_code"`
+	// WorkflowRunID is the workflow run ID.
+	WorkflowRunID string `json:"workflow_run_id"`
+	// CreatedAt is the creation time, Unix timestamp in seconds.
+	CreatedAt int64 `json:"created_at"`
+	// UpdatedAt is the last updated time, Unix timestamp in seconds.
+	UpdatedAt int64 `json:"updated_at"`
+	// Chunks are the content chunks of the message.
+	Chunks []ChatMessageChunk `json:"chunks"`
+	// Extends is the extension payload, kept as raw JSON.
+	Extends json.RawMessage `json:"extends"`
+}
+
+// ChatInfo is the chat summary carried in the ChatDetail response.
+type ChatInfo struct {
+	// ID is the chat ID.
+	ID int64 `json:"id"`
+	// Name is the chat name (title).
+	Name string `json:"name"`
+	// UID is the chat UID.
+	UID string `json:"uid"`
+}
+
+// ChatDetail is the response for AgentContext.Chat.
+type ChatDetail struct {
+	// Chat is the chat summary.
+	Chat ChatInfo `json:"chat"`
+	// ChatRelation is the Agent / permission relation metadata, kept as raw
+	// JSON.
+	ChatRelation json.RawMessage `json:"chat_relation"`
+	// Messages are the messages in the chat.
+	Messages []ChatMessage `json:"messages"`
+}
+
 // ─── Conversation ─────────────────────────────────────────────────────────
 
 // ConversationStatus is the final run status of a conversation.


### PR DESCRIPTION
Adds two AI Agent read endpoints to the Go SDK (mirrors the openapi core change).

## Endpoints
- `AgentContext.Chats(ctx, *GetChatsOptions)` — `GET /v1/ai/chats` — list the account's chats across Agents. Optional `Page` / `Limit` / `ExcludeAgentUIDs`.
- `AgentContext.Chat(ctx, chatUID)` — `GET /v1/ai/chats/{chatUID}` — a single chat's detail with its messages.

## New types
`Chat`, `ChatsResponse`, `ChatMessage`, `ChatMessageChunk`, `ChatInfo`, `ChatDetail`, `GetChatsOptions`.

Stable scalar fields and message `Chunks` are typed; the deeply-nested `ChatRelation` and message `Extends` are kept as `json.RawMessage` (matching how `Reference.Content` is handled).

Response schema verified against the test environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)