### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **AI Agent:** new `agent` package (`AgentContext`) for the AI Agent conversation API:
   - `Workspaces` (`GET /v1/ai/workspaces`) and `Agents` (`GET /v1/ai/workspaces/{id}/agents`)
+  - `PublicAgents` (`GET /v1/ai/agents`) — lists all publicly available Agents on the platform (the Explore catalog); unlike `Agents` it is not scoped to a Workspace and returns every published, publicly-shared Agent. Takes the same optional `page` / `limit` / `name` parameters and returns the same `AgentsResponse`
   - `Conversation` / `Continue` — blocking `POST .../conversations` and `.../continue` (dedicated 120s request timeout; the plain `Workspaces` / `Agents` GETs use 15s)
   - `ConversationStream` / `ContinueStream` — SSE variants returning a `*ConversationStream` iterator (`Next` / `Event` / `Err` / `Close`), unbounded except for `ctx` cancellation. Events are modeled as an interface with 7 concrete types (`ChatStartedEvent`, `WorkflowStartedEvent`, `MessageEvent`, `PingEvent`, `ChatFinishedEvent`, `WorkflowFinishedEvent`, `ChatTitleUpdatedEvent`) plus an `OtherEvent` fallback for forward compatibility
   - `Conversation` / `ConversationStream` take a `parentMessageID` to attach a follow-up after a specific earlier message — only valid together with a non-empty `chatUID`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Changelog
 
-## [Unreleased]
+## [v0.27.0] - 2026-08-14
 
 ### Added
 
-- **AI Agent:** `agent.Interrupt` now exposes `Interactions` — a slice of the new `agent.HumanInteraction` type (`ToolCallID`, `InterruptID`, `InteractionType`, `ToolName`, `Questions`, and the raw `ToolArgs`) — and `agent.QuestionOption` now exposes `Label`. A `null` `questions` / `interactions` list from the server is tolerated (decodes to an empty slice)
+- **AI Agent:** new `agent` package (`AgentContext`) for the AI Agent conversation API:
+  - `Workspaces` (`GET /v1/ai/workspaces`) and `Agents` (`GET /v1/ai/workspaces/{id}/agents`)
+  - `Conversation` / `Continue` — blocking `POST .../conversations` and `.../continue` (dedicated 120s request timeout; the plain `Workspaces` / `Agents` GETs use 15s)
+  - `ConversationStream` / `ContinueStream` — SSE variants returning a `*ConversationStream` iterator (`Next` / `Event` / `Err` / `Close`), unbounded except for `ctx` cancellation. Events are modeled as an interface with 7 concrete types (`ChatStartedEvent`, `WorkflowStartedEvent`, `MessageEvent`, `PingEvent`, `ChatFinishedEvent`, `WorkflowFinishedEvent`, `ChatTitleUpdatedEvent`) plus an `OtherEvent` fallback for forward compatibility
+  - `Conversation` / `ConversationStream` take a `parentMessageID` to attach a follow-up after a specific earlier message — only valid together with a non-empty `chatUID`
+  - `ConversationResponse.FurtherQuestions` — the "you might also ask" follow-up suggestions carried in the `workflow_finished` outputs
+  - `Reference` captures the full source payload the server sends — `OriginalIndex`, `RefType` (wire `type`), `ID`, and the nested `Content` (`json.RawMessage`); previously `Title` / `URL` came back empty and `source` / `description` / `published_at` / … were lost entirely
+  - `ChatStartedEvent` carries `ChatID`, `Error`, and `ErrorMessage`
+  - `Interrupt.Interactions` — a slice of `HumanInteraction` (`ToolCallID`, `InterruptID`, `InteractionType`, `ToolName`, `Questions`, and the raw `ToolArgs`) — and `QuestionOption.Label`; a `null` `questions` / `interactions` list from the server is tolerated (decodes to an empty slice)
+  - `message_id` fields accept either a JSON string or a raw number, matching the other SDKs' defensive deserialization
+- **http:** new `CallSSE` (streaming call, returns the raw response body instead of buffering it) and `WithRequestTimeout` request option, added to support the streaming AI Agent calls
 - **Attached order (take-profit / stop-loss) support** for `SubmitOrder` and `ReplaceOrder`:
   - New types: `AttachedOrderType` (`AttachedOrderTypeProfitTaker` / `AttachedOrderTypeStopLoss` / `AttachedOrderTypeBracket`), `AttachedOrderDetail`, `SubmitAttachedParams`, `ReplaceAttachedParams`
   - `SubmitOrder` / `ReplaceOrder`: new `AttachedParams` field

--- a/agent/context.go
+++ b/agent/context.go
@@ -89,6 +89,35 @@ func (c *AgentContext) Workspaces(ctx context.Context) (*WorkspacesResponse, err
 //
 // Path: GET /v1/ai/workspaces/{id}/agents
 func (c *AgentContext) Agents(ctx context.Context, workspaceID string, opts *GetAgentsOptions) (*AgentsResponse, error) {
+	path := "/v1/ai/workspaces/" + url.PathEscape(workspaceID) + "/agents"
+	var resp AgentsResponse
+	if err := c.httpClient.Get(ctx, path, agentsQuery(opts), &resp, httplib.WithRequestTimeout(listTimeout)); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// PublicAgents lists all publicly available Agents on the platform (the
+// Explore catalog). Unlike Agents, it is not scoped to a Workspace and
+// returns every published, publicly-shared Agent. opts is optional; pass nil
+// to use the server defaults (page 1, limit 20, no name filter).
+//
+// The returned Agent.UID is the identifier used by Conversation; only Agents
+// with IsPublished set can start conversations.
+//
+// Path: GET /v1/ai/agents
+func (c *AgentContext) PublicAgents(ctx context.Context, opts *GetAgentsOptions) (*AgentsResponse, error) {
+	var resp AgentsResponse
+	if err := c.httpClient.Get(ctx, "/v1/ai/agents", agentsQuery(opts), &resp, httplib.WithRequestTimeout(listTimeout)); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// agentsQuery builds the shared optional query parameters (page / limit /
+// name) for Agents and PublicAgents. A nil opts yields an empty set, i.e. the
+// server defaults.
+func agentsQuery(opts *GetAgentsOptions) url.Values {
 	q := url.Values{}
 	if opts != nil {
 		if opts.Page > 0 {
@@ -101,12 +130,7 @@ func (c *AgentContext) Agents(ctx context.Context, workspaceID string, opts *Get
 			q.Set("name", opts.Name)
 		}
 	}
-	path := "/v1/ai/workspaces/" + url.PathEscape(workspaceID) + "/agents"
-	var resp AgentsResponse
-	if err := c.httpClient.Get(ctx, path, q, &resp, httplib.WithRequestTimeout(listTimeout)); err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return q
 }
 
 // Conversation asks a question to the specified Agent, blocking until the


### PR DESCRIPTION
Release **v0.27.0** of the Go SDK.

Closes out the `[Unreleased]` CHANGELOG section as `[v0.27.0] - 2026-08-14`.

### Included since v0.26.0
- **AI Agent conversation API** — new `agent` package (`AgentContext`): `Workspaces` / `Agents` / `PublicAgents` (`GET /v1/ai/agents`, the Explore catalog), blocking `Conversation` / `Continue`, SSE `ConversationStream` / `ContinueStream` with a typed event iterator, `parentMessageID` follow-ups, `FurtherQuestions`, full `Reference` payload, `ChatStartedEvent` fields, and `Interrupt.Interactions` / `QuestionOption.Label`.
- **http:** `CallSSE` and `WithRequestTimeout` (support the streaming agent calls).
- **Attached order (take-profit / stop-loss) support** for `SubmitOrder` / `ReplaceOrder`.
- **Breaking:** `OrderDetail.ChargeDetail` is now `*OrderChargeDetail`.

### Notable in this PR
- **`PublicAgents` was missing from the Go SDK** — added here to match `public_agents` in the Rust/Python/Node.js/Java/C bindings. Reuses `GetAgentsOptions` / `AgentsResponse`; the shared page/limit/name query builder is extracted.
- **CHANGELOG backfill:** the AI Agent conversation API (#109), `parent_message_id`, `FurtherQuestions` (#112) and `Reference` / `ChatStartedEvent` (#113) had landed **without** CHANGELOG entries — documented here so the release notes are complete.

### NOT included
- Grid trading was reverted (#115) and is intentionally excluded until the gateway is live.

### To publish after merge
Go modules release by tag — no publish workflow:
```
git tag v0.27.0 <merge-sha> && git push origin v0.27.0
```
`go build ./...` / `go vet ./agent/` clean on this branch.